### PR TITLE
Footer styling

### DIFF
--- a/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -30,7 +30,7 @@ const Footer = ({ intl }) => {
   return (
     <div id="footer">
       <Container layout className="footer">
-        <div>
+        <div className="footer-message">
           <FormattedMessage
             id="The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
             defaultMessage="The {plonecms} is {copyright} 2000-{current_year} by the {plonefoundation} and friends."
@@ -116,7 +116,7 @@ const Footer = ({ intl }) => {
         <div className="logo">
           <Logo />
         </div>
-        <a className="item" href="https://plone.org">
+        <a className="item powered-by" href="https://plone.org">
           <FormattedMessage
             id="Powered by Plone & Python"
             defaultMessage="Powered by Plone & Python"

--- a/src/theme/_footer.scss
+++ b/src/theme/_footer.scss
@@ -8,11 +8,11 @@
     font-size: 18px;
     height: inherit;
 
-    > a:nth-child(4){
+    a.powered-by {
       font-size: 14px;
     }
 
-    div {
+    .footer-message {
       font-weight: $bold !important;
       a {
         font-weight: inherit;

--- a/src/theme/_footer.scss
+++ b/src/theme/_footer.scss
@@ -1,22 +1,37 @@
 #footer {
   text-align: center;
+  height: 429px;
 
   .footer {
-    padding: 5.5em 2em;
+    padding: 4.2em 2em;
     background-color: $lightgrey;
     font-size: 18px;
-    font-weight: $bold;
+    height: inherit;
+
+    > a:nth-child(4){
+      font-size: 14px;
+    }
+
+    div {
+      font-weight: $bold !important;
+      a {
+        font-weight: inherit;
+      }
+    }
+
 
     ul {
       display: flex;
       justify-content: center;
-      margin-top: 1.8em;
+      margin-top: 1.4em;
+      padding-left: 0;
       list-style: none;
 
       li {
-        padding: 0 5px;
+        padding: 0 7px;
         border-right: 1px solid #205c90;
         font-size: 18px;
+        
 
         &:last-of-type {
           border: none;

--- a/src/theme/_footer.scss
+++ b/src/theme/_footer.scss
@@ -1,19 +1,18 @@
 #footer {
   text-align: center;
-  height: 429px;
+  height: fit-content;
 
   .footer {
-    padding: 4.2em 2em;
+    padding: 4.2rem 2rem;
     background-color: $lightgrey;
     font-size: 18px;
-    height: inherit;
 
     a.powered-by {
       font-size: 14px;
     }
 
     .footer-message {
-      font-weight: $bold !important;
+      font-weight: $bold;
       a {
         font-weight: inherit;
       }
@@ -23,7 +22,7 @@
     ul {
       display: flex;
       justify-content: center;
-      margin-top: 1.4em;
+      margin-top: 1.4rem;
       padding-left: 0;
       list-style: none;
 
@@ -40,7 +39,7 @@
     }
 
     .logo {
-      margin: 5em 0 1.8em 0;
+      margin: 5rem 0 1.8rem 0;
     }
   }
 }

--- a/src/theme/_footer.scss
+++ b/src/theme/_footer.scss
@@ -1,6 +1,5 @@
 #footer {
   text-align: center;
-  height: fit-content;
 
   .footer {
     padding: 4.2rem 2rem;


### PR DESCRIPTION
Regarding: https://github.com/kitconcept/bfs-intranet/issues/26

- Resized footer to match Figma example
- Changed font-weights
- Aligned links to center and adjusted spacing
- Reduced font-size for "Powered by" link

Screenshot:
<img width="1069" alt="Screenshot" src="https://user-images.githubusercontent.com/89805481/208485327-70624c11-9ec0-41e2-a7dc-6654231f840c.png">
