### PR TITLE
Add config for heading block to allow only h2

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,12 @@ const applyConfig = (config) => {
     sidebarTab: 1,
   };
 
+  config.blocks.blocksConfig.heading = {
+    ...config.blocks.blocksConfig.heading,
+    sidebarTab: 0,
+    allowed_headings: [['h2', 'h2']],
+  };
+
   return config;
 };
 


### PR DESCRIPTION
- Allow only h2 for heading block
Meant to be merged along with: 
https://github.com/kitconcept/bfs-intranet/pull/55