### PR TITLE
Amend wrong breakpoint, add comments

### DIFF
--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -4,6 +4,9 @@
   --narrow-container-width: 620px;
 }
 
+// Container queries still do not work with CSS properties
+// They should be exact numbers
+// For now, maintain in sync with the above
 $layout-container-width: 1440px;
 $default-container-width: 940px;
 $narrow-container-width: 620px;

--- a/src/theme/_variables.scss
+++ b/src/theme/_variables.scss
@@ -25,12 +25,13 @@ $page-font: var(--custom-main-font, $page-font-template);
 $header-font: var(--custom-headers-font, $page-font);
 
 // Breakpoints
-$largest-mobile-screen: 768px;
+// Mobile / Tablet portrait < 769 | Tablet landscape / Small desktop < 941 | Computer desktop < 1440 | Large Monitor > 1440
+$largest-mobile-screen: 768px; // not finished in `-width` for historical reasons (SemanticUI naming)
 $tablet-breakpoint: 769px;
-$computer-breakpoint: 1012px;
 $computer-width: 940px;
-$large-monitor-breakpoint: 1441px;
+$computer-breakpoint: 941px;
 $large-monitor-width: 1440px;
+$large-monitor-breakpoint: 1441px;
 
 // Rest of theme variables
 

--- a/src/theme/globals/site.variables
+++ b/src/theme/globals/site.variables
@@ -42,7 +42,7 @@
 // Breakpoints
 @tabletBreakpoint: 769px;
 @computerWidth: 940px;
-@computerBreakpoint: 1012px;
+@computerBreakpoint: 941px;
 @largeMonitorWidth: 1440px;
 @largeMonitorBreakpoint: 1441px;
 


### PR DESCRIPTION
I amended the computer breakpoint that was off. 

@danalvrz @davisagli please tell me if that's correct and check if that breaks other things, but I think now it's correct.

The breakpoints summary:
Mobile / Tablet portrait < 769 | Tablet landscape / Small desktop < 941 | Computer desktop < 1440 | Large Monitor > 1440

Although we are syncronising the breakpoints in both the theme and SemantiUI, we have to be conscious that could be that some CSS coming from semantic is off and should be amended. We have to watch out for it.

I added some comments too.