### PR TITLE
Fix stylelint, enforce latest @plone/scripts

### DIFF
--- a/news/48.bugfix
+++ b/news/48.bugfix
@@ -1,0 +1,1 @@
+Fix stylelint @sneridagh

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "i18n": "rm -rf build/messages && NODE_ENV=production i18n --addon"
   },
   "devDependencies": {
-    "@plone/scripts": "^2.2.2",
+    "@plone/scripts": "^2.3.0",
     "postcss-scss": "4.0.6",
     "prettier": "2.0.5",
     "razzle-plugin-scss": "4.2.18",

--- a/src/theme/_footer.scss
+++ b/src/theme/_footer.scss
@@ -21,8 +21,8 @@
     ul {
       display: flex;
       justify-content: center;
-      margin-top: 1.4rem;
       padding-left: 0;
+      margin-top: 1.4rem;
       list-style: none;
 
       li {

--- a/src/theme/_header.scss
+++ b/src/theme/_header.scss
@@ -5,20 +5,20 @@
   .logo-nav-wrapper {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
     flex-grow: 2;
+    align-items: baseline;
+    justify-content: space-between;
     padding-top: 2rem;
     padding-bottom: 1rem;
-    align-items: baseline;
 
     .logo {
       align-self: center;
     }
 
     .navigation {
+      display: flex;
       flex-grow: 2;
       align-self: center;
-      display: flex;
       justify-content: center;
 
       .desktop.menu {
@@ -78,22 +78,22 @@
       }
 
       button {
-        border: none;
         width: 75px;
         height: 75px;
+        border: none;
         background-color: transparent;
         border-radius: 50%;
         transition: background-color 200ms ease-in-out, color 300ms ease-in-out;
 
         svg {
-          transition-property: transform;
           transition: transform 300ms ease-in-out;
+          transition-property: transform;
         }
 
         &:hover {
-          cursor: pointer;
           background-color: $darkGrey;
           color: $white;
+          cursor: pointer;
 
           svg {
             transform: scale(0.75);
@@ -101,22 +101,22 @@
         }
         &:active {
           transform: scale(0.85);
-          transition-property: transform;
           transition-duration: 100ms;
+          transition-property: transform;
         }
       }
 
       .search-bar {
         position: absolute;
-        padding-top: 2rem;
         z-index: 10;
         top: -135px;
         left: 0;
         width: 100%;
         height: 90px;
+        padding-top: 2rem;
         background-color: $lightgrey;
-        transition-property: top height;
         transition: top 500ms ease-in-out, height 600ms ease-in-out;
+        transition-property: top height;
 
         &.active {
           top: 0;
@@ -138,25 +138,25 @@
 
             .searchbox {
               justify-content: space-between;
-              border-left: none;
-              border-bottom: 2px solid $black;
-              margin-left: 12.6rem;
-              padding-bottom: 0.5rem;
               padding-top: 0;
+              padding-bottom: 0.5rem;
+              border-bottom: 2px solid $black;
+              border-left: none;
+              margin-left: 12.6rem;
 
               @media only screen and (max-width: $tablet-breakpoint) {
-                margin-left: 0.5rem;
                 padding-top: 2rem;
+                margin-left: 0.5rem;
               }
               @media only screen and (max-width: $large-monitor-breakpoint) {
                 padding-top: 0;
               }
 
               input {
-                width: 70%;
                 overflow: hidden;
-                margin-right: 1rem;
+                width: 70%;
                 padding-left: 0;
+                margin-right: 1rem;
                 background-color: $lightgrey;
                 color: $black;
                 font-size: 1.5rem;
@@ -171,10 +171,10 @@
               }
 
               button {
-                padding: 10px;
-                margin-right: 7px;
                 width: 75px;
                 height: 75px;
+                padding: 10px;
+                margin-right: 7px;
 
                 &:hover {
                   background-color: $darkGrey;
@@ -211,10 +211,10 @@
       display: flex;
     }
     .tools a {
+      margin-right: 10px;
       color: $black;
       font-size: 14px;
       text-align: center;
-      margin-right: 10px;
     }
 
     .tools a::after {
@@ -235,8 +235,8 @@
       margin-right: 10px;
 
       a {
-        color: $black;
         margin-right: 0;
+        color: $black;
       }
 
       > div {

--- a/src/theme/_typo-custom.scss
+++ b/src/theme/_typo-custom.scss
@@ -34,42 +34,42 @@ h1.documentFirstHeading {
 
 // Heading block
 .heading-wrapper h2 {
-  font-weight: $light;
-  font-size: 52px;
-  line-height: 60px;
   padding-top: 4rem;
   padding-bottom: 2rem;
+  font-size: 52px;
+  font-weight: $light;
+  line-height: 60px;
 }
 .heading-wrapper h3 {
-  font-weight: $light;
-  font-size: 42px;
-  line-height: 48px;
   padding-top: 3rem;
   padding-bottom: 1rem;
+  font-size: 42px;
+  font-weight: $light;
+  line-height: 48px;
 }
 
 // Slate headings
 h2 {
-  font-weight: $bold;
-  font-size: 48px;
-  line-height: 56px;
   padding-top: 2.5rem;
   padding-bottom: 1rem;
+  font-size: 48px;
+  font-weight: $bold;
+  line-height: 56px;
   span {
-    font-weight: inherit;
     font-size: inherit;
+    font-weight: inherit;
     line-height: inherit;
   }
 }
 h3 {
-  font-weight: $bold;
-  font-size: 36px;
-  line-height: 42px;
   padding-top: 1.5rem;
   padding-bottom: 0.3rem;
+  font-size: 36px;
+  font-weight: $bold;
+  line-height: 42px;
   span {
-    font-weight: inherit;
     font-size: inherit;
+    font-weight: inherit;
     line-height: inherit;
   }
 }

--- a/src/theme/blocks/_grid.scss
+++ b/src/theme/blocks/_grid.scss
@@ -1,16 +1,16 @@
 .block.__grid {
-  margin-bottom: 0;
   margin-top: 0;
+  margin-bottom: 0;
 
   .teaser {
     margin-bottom: 0;
   }
 
   .headline {
-    font-weight: 300;
-    font-size: 42px;
-    line-height: 48px;
     margin-left: 0.3rem !important;
+    font-size: 42px;
+    font-weight: 300;
+    line-height: 48px;
   }
 }
 
@@ -23,21 +23,21 @@
 }
 
 .grid-block-image {
-  padding-bottom: 0;
   padding-top: 0 !important;
+  padding-bottom: 0;
 
   figcaption {
     position: absolute;
-    bottom: 0;
     z-index: 100;
+    bottom: 0;
     padding: 1rem 1rem 0.5rem 1rem;
 
     .title {
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      font-size: 18px;
-      line-height: 22px;
       color: $white !important;
+      font-size: 18px;
+      letter-spacing: 1px;
+      line-height: 22px;
+      text-transform: uppercase;
     }
 
     .description {
@@ -45,9 +45,9 @@
     }
 
     .credits {
-      font-size: 10px;
       margin-bottom: 0;
       color: $white !important;
+      font-size: 10px;
     }
   }
   img {
@@ -61,19 +61,19 @@
   }
 
   figure:after {
-    content: '';
     position: absolute;
     bottom: 0;
     width: 100%;
     height: 35%;
     background-color: $black;
+    content: '';
     opacity: 0.75;
   }
 }
 
 .slate {
-  background-color: $lightgrey;
   margin: 0 !important;
+  background-color: $lightgrey;
   p {
     padding: 1.5rem 1.5rem 2.4rem 1.5rem !important;
   }
@@ -87,9 +87,9 @@
     background: white;
   }
   .slate {
-    background-color: $white;
     padding: 0 !important;
     margin: 0 1rem 1rem 1rem;
+    background-color: $white;
   }
 
   .grid-block-image {

--- a/src/theme/blocks/_teaser.scss
+++ b/src/theme/blocks/_teaser.scss
@@ -105,10 +105,10 @@
 .two.column,
 .one {
   .content h2 {
-    font-size: 48px !important;
-    line-height: 56px !important;
     padding-top: 20px !important;
     padding-bottom: 40px !important;
+    font-size: 48px !important;
+    line-height: 56px !important;
   }
 }
 
@@ -121,8 +121,8 @@
       line-height: 24px;
 
       h2 {
-        font-weight: 700;
         padding-bottom: 20px;
+        font-weight: 700;
       }
     }
   }
@@ -140,14 +140,14 @@
     align-self: flex-start;
 
     .headline {
-      letter-spacing: 1px;
-      text-transform: uppercase;
       padding-bottom: 20px;
       margin: 0;
       color: $black;
       font-size: 16px;
       font-weight: 700;
+      letter-spacing: 1px;
       line-height: 20px;
+      text-transform: uppercase;
     }
 
     h2 {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1556,7 +1556,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@kitconcept/volto-light-theme@workspace:."
   dependencies:
-    "@plone/scripts": ^2.2.2
+    "@plone/scripts": ^2.3.0
     postcss-scss: 4.0.6
     prettier: 2.0.5
     razzle-plugin-scss: 4.2.18
@@ -1603,9 +1603,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@plone/scripts@npm:^2.2.2":
-  version: 2.2.2
-  resolution: "@plone/scripts@npm:2.2.2"
+"@plone/scripts@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "@plone/scripts@npm:2.3.0"
   dependencies:
     babel-plugin-react-intl: 5.1.17
     babel-preset-razzle: 4.2.17
@@ -1620,7 +1620,7 @@ __metadata:
     addon: addon/index.js
     changelogupdater: changelogupdater.cjs
     i18n: i18n.cjs
-  checksum: 33d63c1d0fe096984aa3a37b0842f65f13ef84065ffa88f66b6ada38c73a545f2236c8d24987881c50be36c903ec4b96bf5dc63dc3e4409985174efc122f737a
+  checksum: 32dbbe4f9233e8d9b16ffc451c42d4753907b3f700665a4bed796c5642194890d8bda21deddd3d1efb1559df288b29c69d32cf7437f6f4ef0a5113722b6b79ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Turns out, that the generator was not checking for sass files. From now on it will. @danalvrz please depending in the IDE you are using, try to configure an automatic formatter for stylelint. In vscode, installing the extension is enough, configuring it for running on save for style files. Let me know if you have any issue.