### PR TITLE
Fix grids in edit mode

### DIFF
--- a/news/49.bugfix
+++ b/news/49.bugfix
@@ -1,0 +1,1 @@
+Fix grids in edit mode @sneridagh

--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -173,7 +173,6 @@ $narrow-container-width: 620px;
 
 // Grids adjustments (has to be paired with collections/grid.variables)
 // TODO: Move to our own grid component
-.block.__grid,
 .block.__grid .ui.stackable {
   @include default-container-width();
   max-width: calc(var(--default-container-width) + 1rem);

--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -118,6 +118,8 @@ $narrow-container-width: 620px;
 }
 
 // Setting a default, for all blocks
+// We want all blocks in edit go layout by default
+// But block's inner containers can go less (eg. grid)
 #page-add,
 #page-edit {
   [class*='block-editor-'] {
@@ -171,12 +173,10 @@ $narrow-container-width: 620px;
 
 // Grids adjustments (has to be paired with collections/grid.variables)
 // TODO: Move to our own grid component
-#page-document > {
-  .block.__grid,
-  .block.__grid .ui.stackable {
-    @include default-container-width();
-    max-width: calc(var(--default-container-width) + 1rem);
-  }
+.block.__grid,
+.block.__grid .ui.stackable {
+  @include default-container-width();
+  max-width: calc(var(--default-container-width) + 1rem);
 }
 
 // handlers adjustments


### PR DESCRIPTION
@danalvrz please ping me for this one. Why did you constrained to `#page-document` in the first place? Could be that I'm breaking something now. If so, we can refine better the selector.

