### PR TITLE
Change full variant separator to default width

### DIFF
--- a/news/59.bugfix
+++ b/news/59.bugfix
@@ -1,0 +1,1 @@
+Minor width fix to separator full variant @danalvrz

--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -98,14 +98,13 @@ $narrow-container-width: 620px;
   & > .block.listing .listing-item,
   & > .block h2.headline,
   & > .block.heading .heading-wrapper,
-  & > .block.separator .line,
+  & > .block.separator.has--align--full .line,
   & > .block.teaser .grid-teaser-item.default,
   & > .slate blockquote {
     @include default-container-width();
   }
 
   & > .block.teaser,
-  & > .block.separator.has--align--full .line,
   & > .block.image.align.full,
   & > .block.video.align.full,
   & > .block.maps.align.full {


### PR DESCRIPTION
- Assign default-width to separator when in full variant