### PR TITLE
Add experimental support for automatic block grouping in the editor

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,15 @@
+name: Unit Tests
+on: [push]
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+      - name: Main checkout
+        uses: actions/checkout@v3
+
+      - name: Unit tests
+        run: make test-ci

--- a/news/83.feature
+++ b/news/83.feature
@@ -1,0 +1,1 @@
+Add auto block grouping per backgroundColor @sneridagh

--- a/src/customizations/volto/components/manage/DragDropList/DragDropList.jsx
+++ b/src/customizations/volto/components/manage/DragDropList/DragDropList.jsx
@@ -1,0 +1,241 @@
+/**
+ * OVERRIDE DragDropList.jsx
+ * REASON: This version enables auto-grouping of blocks in the editor that share the same style property
+ * in the StylingWrapper. In the future one could improve it by enabling a way to choose the
+ * grouping property, eg. using a property other than `backgroundColor`.
+ * FILE: https://github.com/plone/volto/blob/a9c4c089c42e5ceb981aaeb4e411096df206b3e2/src/components/manage/DragDropList/DragDropList.jsx#L123
+ * FILE VERSION: Volto 17.0.0-alpha.8
+ * DATE: 2023-05-29
+ * DEVELOPER: @sneridagh
+ */
+import React, { useRef } from 'react';
+import { isEmpty, map } from 'lodash';
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import { v4 as uuid } from 'uuid';
+import cx from 'classnames';
+import MaybeWrap from '@plone/volto/components/manage/MaybeWrap/MaybeWrap';
+import config from '@plone/volto/registry';
+
+export function groupByBGColor(childList) {
+  const result = [];
+  let currentArr = [];
+  let currentBGColor;
+
+  childList.forEach(([blockId, block]) => {
+    if (block?.styles?.backgroundColor) {
+      if (block.styles.backgroundColor !== currentBGColor) {
+        currentBGColor = block.styles.backgroundColor;
+        if (currentArr.length > 0) {
+          result.push(currentArr);
+          currentArr = [];
+        }
+      }
+    } else {
+      if (currentBGColor) {
+        currentBGColor = '';
+        result.push(currentArr);
+        currentArr = [];
+      }
+    }
+    currentArr.push([blockId, block]);
+  });
+  result.push(currentArr);
+  return result;
+}
+
+const getPlaceholder = (draggedDOM, sourceIndex, destinationIndex, uid) => {
+  // Because of the margin rendering rules, there is no easy
+  // way to calculate the offset of the placeholder.
+  //
+  // (Note that this is the reason we cannot use the solutions
+  // published on the net, because they assume that we are in control
+  // of the content and there are no additional margins involved.)
+  //
+  // To get a placeholder that looks good in all cases, we
+  // fill up the space between the previous and the next element.
+  const queryAttr = 'data-rbd-droppable-id';
+  const domQuery = `[${queryAttr}='${uid}']`;
+  const parentDOM = document.querySelector(domQuery);
+
+  const childrenArray = [...parentDOM.children];
+  // Remove the source element
+  childrenArray.splice(sourceIndex, 1);
+  // Also remove the placeholder that the library always inserts at the end
+  childrenArray.splice(-1, 1);
+  const parentRect = parentDOM.getBoundingClientRect();
+  const prevNode = childrenArray[destinationIndex - 1];
+  const nextNode = childrenArray[destinationIndex];
+  let top, bottom;
+  if (prevNode) {
+    const prevRect = prevNode.getBoundingClientRect();
+    top = prevRect.top + prevRect.height - parentRect.top;
+  } else {
+    top = 0;
+  }
+  if (nextNode) {
+    const nextRect = nextNode.getBoundingClientRect();
+    bottom = nextRect.top - parentRect.top;
+  } else {
+    bottom =
+      parentRect.bottom +
+      draggedDOM.getBoundingClientRect().height -
+      parentRect.top;
+  }
+  return {
+    clientY: top,
+    clientHeight: bottom - top,
+    clientX: parseFloat(window.getComputedStyle(parentDOM).paddingLeft),
+    clientWidth: draggedDOM.clientWidth,
+  };
+};
+
+const DragDropList = (props) => {
+  const {
+    childList,
+    children,
+    onMoveItem,
+    as = 'div',
+    style,
+    forwardedAriaLabelledBy,
+    reactBeautifulDnd,
+  } = props; //renderChild
+  const { DragDropContext, Draggable, Droppable } = reactBeautifulDnd;
+  const [placeholderProps, setPlaceholderProps] = React.useState({});
+  const [uid] = React.useState(uuid());
+  // queueing timed action
+  const timer = useRef(null);
+
+  const onDragStart = React.useCallback(
+    (event) => {
+      clearTimeout(timer.current);
+      const queryAttr = 'data-rbd-draggable-id';
+      const domQuery = `[${queryAttr}='${event.draggableId}']`;
+      const draggedDOM = document.querySelector(domQuery);
+      if (!draggedDOM) {
+        return;
+      }
+      const sourceIndex = event.source.index;
+      setPlaceholderProps(
+        getPlaceholder(draggedDOM, sourceIndex, sourceIndex, uid),
+      );
+    },
+    [uid],
+  );
+
+  const onDragEnd = React.useCallback(
+    (result) => {
+      clearTimeout(timer.current);
+      onMoveItem(result);
+      setPlaceholderProps({});
+    },
+    [onMoveItem],
+  );
+
+  const onDragUpdate = React.useCallback(
+    (update) => {
+      clearTimeout(timer.current);
+      setPlaceholderProps({});
+      if (!update.destination) {
+        return;
+      }
+      const draggableId = update.draggableId;
+      const queryAttr = 'data-rbd-draggable-id';
+      const domQuery = `[${queryAttr}='${draggableId}']`;
+      const draggedDOM = document.querySelector(domQuery);
+      if (!draggedDOM) {
+        return;
+      }
+      const sourceIndex = update.source.index;
+      const destinationIndex = update.destination.index;
+      // Wait until the animations have finished, to make it look good.
+      timer.current = setTimeout(
+        () =>
+          setPlaceholderProps(
+            getPlaceholder(draggedDOM, sourceIndex, destinationIndex, uid),
+          ),
+        250,
+      );
+    },
+    [uid],
+  );
+
+  const AsDomComponent = as;
+
+  const grouped = groupByBGColor(childList);
+  console.log(grouped);
+  return (
+    <DragDropContext
+      onDragStart={onDragStart}
+      onDragUpdate={onDragUpdate}
+      onDragEnd={onDragEnd}
+    >
+      <Droppable
+        droppableId={uid}
+        renderClone={(provided, snapshot, rubric) => {
+          const index = rubric.source.index;
+          return children({
+            child: childList[index][1],
+            childId: childList[index][0],
+            index,
+            draginfo: provided,
+          });
+        }}
+      >
+        {(provided, snapshot) => (
+          <AsDomComponent
+            ref={provided.innerRef}
+            {...provided.droppableProps}
+            style={{ ...style, position: 'relative' }}
+            aria-labelledby={forwardedAriaLabelledBy}
+          >
+            {map(grouped, (group, index) => (
+              <MaybeWrap
+                key={`block-group-${index}`}
+                condition={
+                  config.settings.enableAutoBlockGroupingByBackgroundColor
+                }
+                className={cx(
+                  'blocks-group-wrapper',
+                  group[0][1]?.styles?.backgroundColor,
+                )}
+              >
+                {group
+                  .filter(([id, child]) => id && child) // beware numbers!
+                  .map(([childId, child], index) => (
+                    <Draggable
+                      draggableId={childId.toString()}
+                      index={index}
+                      key={childId}
+                      style={{
+                        userSelect: 'none',
+                      }}
+                    >
+                      {(draginfo) =>
+                        children({ child, childId, index, draginfo })
+                      }
+                    </Draggable>
+                  ))}
+                {provided.placeholder}
+                {!isEmpty(placeholderProps) && snapshot.isDraggingOver && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: placeholderProps.clientY,
+                      left: placeholderProps.clientX,
+                      height: placeholderProps.clientHeight,
+                      background: '#eee',
+                      width: placeholderProps.clientWidth,
+                      borderRadius: '3px',
+                    }}
+                  />
+                )}
+              </MaybeWrap>
+            ))}
+          </AsDomComponent>
+        )}
+      </Droppable>
+    </DragDropContext>
+  );
+};
+
+export default injectLazyLibs(['reactBeautifulDnd'])(DragDropList);

--- a/src/customizations/volto/components/theme/View/RenderBlocks.jsx
+++ b/src/customizations/volto/components/theme/View/RenderBlocks.jsx
@@ -1,0 +1,128 @@
+/**
+ * OVERRIDE RenderBlocks.jsx
+ * REASON: This version enables auto-grouping of blocks that share the same style property
+ * in the StylingWrapper. In the future one could improve it by enabling a way to choose the
+ * grouping property, eg. using a property other than `backgroundColor`.
+ * FILE: https://github.com/plone/volto/blob/9882c66da42e5440ca1c949d829b78f2b1328683/src/components/theme/View/RenderBlocks.jsx#L25
+ * FILE VERSION: Volto 17.0.0-alpha.8
+ * DATE: 2023-05-25
+ * DEVELOPER: @sneridagh
+ */
+
+import React from 'react';
+import { getBaseUrl, applyBlockDefaults } from '@plone/volto/helpers';
+import { defineMessages, injectIntl } from 'react-intl';
+import { map } from 'lodash';
+import {
+  getBlocksFieldname,
+  getBlocksLayoutFieldname,
+  hasBlocksData,
+} from '@plone/volto/helpers';
+import StyleWrapper from '@plone/volto/components/manage/Blocks/Block/StyleWrapper';
+import config from '@plone/volto/registry';
+import { ViewDefaultBlock } from '@plone/volto/components';
+import cx from 'classnames';
+import MaybeWrap from '@plone/volto/components/manage/MaybeWrap/MaybeWrap';
+
+const messages = defineMessages({
+  unknownBlock: {
+    id: 'Unknown Block',
+    defaultMessage: 'Unknown Block {block}',
+  },
+  invalidBlock: {
+    id: 'Invalid Block',
+    defaultMessage: 'Invalid block - Will be removed on saving',
+  },
+});
+
+export function groupByBGColor(blocks, blocks_layout) {
+  const result = [];
+  let currentArr = [];
+  let currentBGColor;
+
+  blocks_layout.items.forEach((blockId) => {
+    if (blocks[blockId]?.styles?.backgroundColor) {
+      if (blocks[blockId].styles.backgroundColor !== currentBGColor) {
+        currentBGColor = blocks[blockId].styles.backgroundColor;
+        if (currentArr.length > 0) {
+          result.push(currentArr);
+          currentArr = [];
+        }
+      }
+    } else {
+      if (currentBGColor) {
+        currentBGColor = '';
+        result.push(currentArr);
+        currentArr = [];
+      }
+    }
+    currentArr.push(blockId);
+  });
+  result.push(currentArr);
+  return result;
+}
+
+const RenderBlocks = (props) => {
+  const { content, intl, location, metadata } = props;
+  const blocksFieldname = getBlocksFieldname(content);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(content);
+  const blocksConfig = props.blocksConfig || config.blocks.blocksConfig;
+  const CustomTag = props.as || React.Fragment;
+
+  const grouped = groupByBGColor(
+    content[blocksFieldname],
+    content[blocksLayoutFieldname],
+  );
+
+  return hasBlocksData(content) ? (
+    <CustomTag>
+      {map(grouped, (group) => (
+        <MaybeWrap
+          condition={config.settings.enableAutoBlockGroupingByBackgroundColor}
+          className={cx(
+            'blocks-group-wrapper',
+            content[blocksFieldname][group[0]]?.styles?.backgroundColor,
+          )}
+        >
+          {map(group, (block) => {
+            const Block =
+              blocksConfig[content[blocksFieldname]?.[block]?.['@type']]
+                ?.view || ViewDefaultBlock;
+
+            const blockData = applyBlockDefaults({
+              data: content[blocksFieldname][block],
+              intl,
+              metadata,
+              properties: content,
+            });
+
+            return Block ? (
+              <StyleWrapper key={block} {...props} id={block} data={blockData}>
+                <Block
+                  id={block}
+                  metadata={metadata}
+                  properties={content}
+                  data={blockData}
+                  path={getBaseUrl(location?.pathname || '')}
+                  blocksConfig={blocksConfig}
+                />
+              </StyleWrapper>
+            ) : blockData ? (
+              <div key={block}>
+                {intl.formatMessage(messages.unknownBlock, {
+                  block: content[blocksFieldname]?.[block]?.['@type'],
+                })}
+              </div>
+            ) : (
+              <div key={block}>{intl.formatMessage(messages.invalidBlock)}</div>
+            );
+          })}
+        </MaybeWrap>
+      ))}
+    </CustomTag>
+  ) : (
+    ''
+  );
+};
+
+export default injectIntl(RenderBlocks);

--- a/src/customizations/volto/components/theme/View/RenderBlocks.test.jsx
+++ b/src/customizations/volto/components/theme/View/RenderBlocks.test.jsx
@@ -1,0 +1,258 @@
+import { groupByBGColor } from './RenderBlocks';
+describe('groupByBGColor', () => {
+  it('grid + grid + slate grey', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': '__grid',
+        },
+        2: {
+          '@type': '__grid',
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([[1, 2], [3]]);
+  });
+
+  it('grid + grid grey + slate grey', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': '__grid',
+        },
+        2: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([[1], [2, 3]]);
+  });
+
+  it('slate grey + slate grey + slate grey ', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        2: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([[1, 2, 3]]);
+  });
+
+  it('slate grey + slate + slate grey ', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        2: {
+          '@type': 'slate',
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([
+      [1],
+      [2],
+      [3],
+    ]);
+  });
+
+  it('grid + grid + slate grey + slate grey + slate + slate', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': '__grid',
+        },
+        2: {
+          '@type': '__grid',
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        4: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        5: {
+          '@type': 'slate',
+        },
+        6: {
+          '@type': 'slate',
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3, 4, 5, 6],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('grid + grid + slate grey + slate grey + slate + slate - transparent', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': '__grid',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+        2: {
+          '@type': '__grid',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        4: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        5: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+        6: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3, 4, 5, 6],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+
+  it('grid + grid + slate grey + slate grey + slate + slate - transparent mixed', () => {
+    const content = {
+      blocks: {
+        1: {
+          '@type': '__grid',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+        2: {
+          '@type': '__grid',
+          styles: {
+            backgroundColor: 'transparent',
+          },
+        },
+        3: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        4: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: 'grey',
+          },
+        },
+        5: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: '',
+          },
+        },
+        6: {
+          '@type': 'slate',
+          styles: {
+            backgroundColor: '',
+          },
+        },
+      },
+      blocks_layout: {
+        items: [1, 2, 3, 4, 5, 6],
+      },
+    };
+    const { blocks, blocks_layout } = content;
+    expect(groupByBGColor(blocks, blocks_layout)).toStrictEqual([
+      [1, 2],
+      [3, 4],
+      [5, 6],
+    ]);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,8 @@ defineMessages({
 });
 
 const applyConfig = (config) => {
+  config.settings.enableAutoBlockGroupingByBackgroundColor = true;
+
   // No required blocks (eg. Title)
   config.blocks.requiredBlocks = [];
 

--- a/src/theme/_bgcolor-blocks-layout.scss
+++ b/src/theme/_bgcolor-blocks-layout.scss
@@ -1,0 +1,21 @@
+.blocks-group-wrapper {
+  padding-top: $color-block-change-vertical-spacing;
+  padding-bottom: $color-block-change-vertical-spacing;
+}
+
+.blocks-group-wrapper.grey {
+  background-color: #ecebeb;
+}
+
+#page-document .blocks-group-wrapper {
+  .block:first-child h2.headline {
+    padding-top: 0;
+  }
+}
+
+// For grids
+.block.__grid {
+  &.is--last--of--block-type {
+    margin-bottom: $grid-block-vertical-spacing-bottom;
+  }
+}

--- a/src/theme/_layout.scss
+++ b/src/theme/_layout.scss
@@ -67,7 +67,7 @@ $narrow-container-width: 620px;
 }
 
 // Content Layout Styling
-#page-document {
+#page-document .blocks-group-wrapper {
   & > h2,
   & > h3,
   & > h4,
@@ -206,3 +206,5 @@ body.has-toolbar.has-sidebar .block .ui.basic.button.delete-button {
     text-decoration: underline;
   }
 }
+
+@import 'bgcolor-blocks-layout';


### PR DESCRIPTION
It seems feasible! however there is some UI/UX drawbacks:

<img width="1571" alt="image" src="https://github.com/kitconcept/volto-light-theme/assets/486927/a188eb18-9de8-474c-94e1-5cacfaae2d1f">

The edit block wrapper gets "behind", and the drag and drop (the blocks could get huge, is cumbersome). Maybe this, combined with the new DnD that Rob has been working on and the Navigator...