### PR TITLE
Update to Volto 17a21 + Deprecate `volto-image-block` - Use new core Image component

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -4,7 +4,7 @@ on: [push]
 env:
   ADDON_NAME: "@kitconcept/volto-light-theme"
   ADDON_PATH: "volto-light-theme"
-  VOLTO_VERSION: "17.0.0-alpha.20"
+  VOLTO_VERSION: "17.0.0-alpha.21"
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ on:
 env:
   ENVIRONMENT: "light-theme.kitconcept.io"
   IMAGE_NAME: "ghcr.io/kitconcept/voltolighttheme-frontend"
-  VOLTO_VERSION: "17.0.0-alpha.20"
+  VOLTO_VERSION: "17.0.0-alpha.21"
 
 jobs:
   meta:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ RESET=`tput sgr0`
 YELLOW=`tput setaf 3`
 
 PLONE_VERSION=6
-VOLTO_VERSION=17.0.0-alpha.20
+VOLTO_VERSION=17.0.0-alpha.21
 
 ADDON_NAME='@kitconcept/volto-light-theme'
 ADDON_PATH='volto-light-theme'

--- a/news/177.breaking
+++ b/news/177.breaking
@@ -1,0 +1,4 @@
+Update to Volto 17a21
+Deprecate volto-image-block
+Use new core Image component
+@sneridagh

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@kitconcept/volto-button-block",
     "@kitconcept/volto-dsgvo-banner",
     "@kitconcept/volto-heading-block",
-    "@kitconcept/volto-image-block",
     "@kitconcept/volto-introduction-block",
     "@kitconcept/volto-separator-block",
     "@kitconcept/volto-slider-block"
@@ -66,10 +65,9 @@
     "@kitconcept/volto-button-block": "^2.3.1",
     "@kitconcept/volto-dsgvo-banner": "^1.3.0",
     "@kitconcept/volto-heading-block": "^2.2.0",
-    "@kitconcept/volto-image-block": "^1.0.3",
     "@kitconcept/volto-introduction-block": "^1.0.0",
     "@kitconcept/volto-separator-block": "^3.2.2",
     "@kitconcept/volto-slider-block": "^4.2.0",
-    "@plone/volto": "^17.0.0-alpha.20"
+    "@plone/volto": "^17.0.0-alpha.21"
   }
 }

--- a/src/components/Blocks/Image/Edit.jsx
+++ b/src/components/Blocks/Image/Edit.jsx
@@ -248,9 +248,8 @@ class Edit extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
-    const { blocksConfig, data } = this.props;
+    const { data } = this.props;
     const Image = config.getComponent({ name: 'Image' }).component;
-    const dataAdapter = blocksConfig[data['@type']].dataAdapter;
     const placeholder =
       this.props.data.placeholder ||
       this.props.intl.formatMessage(messages.ImageBlockInputPlaceholder);

--- a/src/components/Blocks/Image/Edit.jsx
+++ b/src/components/Blocks/Image/Edit.jsx
@@ -1,0 +1,474 @@
+/**
+ * Edit image block.
+ * @module components/manage/Blocks/Image/Edit
+ */
+
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import { readAsDataURL } from 'promise-file-reader';
+import { Button, Dimmer, Input, Loader, Message } from 'semantic-ui-react';
+import { defineMessages, injectIntl } from 'react-intl';
+import loadable from '@loadable/component';
+import cx from 'classnames';
+import { isEqual } from 'lodash';
+
+import Caption from '../../Caption/Caption';
+
+import { Icon, ImageSidebar, SidebarPortal } from '@plone/volto/components';
+import { createContent } from '@plone/volto/actions';
+import {
+  flattenToAppURL,
+  getBaseUrl,
+  isInternalURL,
+  withBlockExtensions,
+  validateFileUploadSize,
+} from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
+
+import imageBlockSVG from '@plone/volto/components/manage/Blocks/Image/block-image.svg';
+import clearSVG from '@plone/volto/icons/clear.svg';
+import navTreeSVG from '@plone/volto/icons/nav.svg';
+import aheadSVG from '@plone/volto/icons/ahead.svg';
+import uploadSVG from '@plone/volto/icons/upload.svg';
+
+const Dropzone = loadable(() => import('react-dropzone'));
+
+const messages = defineMessages({
+  ImageBlockInputPlaceholder: {
+    id: 'Browse the site, drop an image, or type an URL',
+    defaultMessage: 'Browse the site, drop an image, or type an URL',
+  },
+  uploadingImage: {
+    id: 'Uploading image',
+    defaultMessage: 'Uploading image',
+  },
+});
+
+/**
+ * Edit image block class.
+ * @class Edit
+ * @extends Component
+ */
+class Edit extends Component {
+  /**
+   * Property types.
+   * @property {Object} propTypes Property types.
+   * @static
+   */
+  static propTypes = {
+    selected: PropTypes.bool.isRequired,
+    block: PropTypes.string.isRequired,
+    index: PropTypes.number.isRequired,
+    data: PropTypes.objectOf(PropTypes.any).isRequired,
+    content: PropTypes.objectOf(PropTypes.any),
+    request: PropTypes.shape({
+      loading: PropTypes.bool,
+      loaded: PropTypes.bool,
+    }).isRequired,
+    pathname: PropTypes.string.isRequired,
+    onChangeBlock: PropTypes.func.isRequired,
+    onSelectBlock: PropTypes.func.isRequired,
+    onDeleteBlock: PropTypes.func.isRequired,
+    onFocusPreviousBlock: PropTypes.func.isRequired,
+    onFocusNextBlock: PropTypes.func.isRequired,
+    handleKeyDown: PropTypes.func.isRequired,
+    createContent: PropTypes.func.isRequired,
+    openObjectBrowser: PropTypes.func.isRequired,
+  };
+
+  state = {
+    uploading: false,
+    url: '',
+    dragging: false,
+  };
+
+  /**
+   * Component will receive props
+   * @method componentWillReceiveProps
+   * @param {Object} nextProps Next properties
+   * @returns {undefined}
+   */
+  UNSAFE_componentWillReceiveProps(nextProps) {
+    // Update block data after upload finished
+    if (
+      this.props.request.loading &&
+      nextProps.request.loaded &&
+      this.state.uploading
+    ) {
+      this.setState({
+        uploading: false,
+      });
+      this.props.onChangeBlock(this.props.block, {
+        ...this.props.data,
+        url: nextProps.content['@id'],
+        image_field: 'image',
+        image_scales: { image: [nextProps.content.image] },
+        alt: '',
+      });
+    }
+  }
+
+  /**
+   * @param {*} nextProps
+   * @returns {boolean}
+   * @memberof Edit
+   */
+  shouldComponentUpdate(nextProps) {
+    return (
+      this.props.selected ||
+      nextProps.selected ||
+      !isEqual(this.props.data, nextProps.data)
+    );
+  }
+
+  /**
+   * Upload image handler (not used), but useful in case that we want a button
+   * not powered by react-dropzone
+   * @method onUploadImage
+   * @returns {undefined}
+   */
+  onUploadImage = (e) => {
+    e.stopPropagation();
+    const file = e.target.files[0];
+    if (!validateFileUploadSize(file, this.props.intl.formatMessage)) return;
+    this.setState({
+      uploading: true,
+    });
+    readAsDataURL(file).then((data) => {
+      const fields = data.match(/^data:(.*);(.*),(.*)$/);
+      this.props.createContent(
+        getBaseUrl(this.props.pathname),
+        {
+          '@type': 'Image',
+          title: file.name,
+          image: {
+            data: fields[3],
+            encoding: fields[2],
+            'content-type': fields[1],
+            filename: file.name,
+          },
+        },
+        this.props.block,
+      );
+    });
+  };
+
+  /**
+   * Change url handler
+   * @method onChangeUrl
+   * @param {Object} target Target object
+   * @returns {undefined}
+   */
+  onChangeUrl = ({ target }) => {
+    this.setState({
+      url: target.value,
+    });
+  };
+
+  /**
+   * Submit url handler
+   * @method onSubmitUrl
+   * @param {object} e Event
+   * @returns {undefined}
+   */
+  onSubmitUrl = () => {
+    this.props.onChangeBlock(this.props.block, {
+      ...this.props.data,
+      url: flattenToAppURL(this.state.url),
+      image_field: undefined,
+      image_scales: undefined,
+    });
+  };
+
+  /**
+   * Drop handler
+   * @method onDrop
+   * @param {array} files File objects
+   * @returns {undefined}
+   */
+  onDrop = (files) => {
+    if (!validateFileUploadSize(files[0], this.props.intl.formatMessage)) {
+      this.setState({ dragging: false });
+      return;
+    }
+    this.setState({ uploading: true });
+
+    readAsDataURL(files[0]).then((data) => {
+      const fields = data.match(/^data:(.*);(.*),(.*)$/);
+      this.props.createContent(
+        getBaseUrl(this.props.pathname),
+        {
+          '@type': 'Image',
+          title: files[0].name,
+          image: {
+            data: fields[3],
+            encoding: fields[2],
+            'content-type': fields[1],
+            filename: files[0].name,
+          },
+        },
+        this.props.block,
+      );
+    });
+  };
+
+  /**
+   * Keydown handler on Variant Menu Form
+   * This is required since the ENTER key is already mapped to a onKeyDown
+   * event and needs to be overriden with a child onKeyDown.
+   * @method onKeyDownVariantMenuForm
+   * @param {Object} e Event object
+   * @returns {undefined}
+   */
+  onKeyDownVariantMenuForm = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      this.onSubmitUrl();
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      e.stopPropagation();
+      // TODO: Do something on ESC key
+    }
+  };
+  onDragEnter = () => {
+    this.setState({ dragging: true });
+  };
+  onDragLeave = () => {
+    this.setState({ dragging: false });
+  };
+
+  node = React.createRef();
+
+  /**
+   * Render method.
+   * @method render
+   * @returns {string} Markup for the component.
+   */
+  render() {
+    const { blocksConfig, data } = this.props;
+    const Image = config.getComponent({ name: 'Image' }).component;
+    const dataAdapter = blocksConfig[data['@type']].dataAdapter;
+    const placeholder =
+      this.props.data.placeholder ||
+      this.props.intl.formatMessage(messages.ImageBlockInputPlaceholder);
+
+    return (
+      <div
+        className={cx(
+          'block image align',
+          {
+            center: !Boolean(data.align),
+          },
+          data.align,
+        )}
+      >
+        {data.url ? (
+          // START CUSTOMIZATION - Added `figure` tag
+          <figure
+            className={cx(
+              'figure',
+              {
+                center: !Boolean(data.align),
+              },
+              data.align,
+              {
+                // START CUSTOMIZATION
+                // 'full-width': data.align === 'full',
+                // END CUSTOMIZATION
+                large: data.size === 'l',
+                medium: data.size === 'm' || !data.size,
+                small: data.size === 's',
+              },
+            )}
+          >
+            <Image
+              // Is this needed?
+              // className={cx({
+              //   'full-width': data.align === 'full',
+              //   large: data.size === 'l',
+              //   medium: data.size === 'm' || !data.size,
+              //   small: data.size === 's',
+              // })}
+              item={
+                data.image_scales
+                  ? {
+                      '@id': data.url,
+                      image_field: data.image_field,
+                      image_scales: data.image_scales,
+                    }
+                  : undefined
+              }
+              src={
+                data.image_scales
+                  ? undefined
+                  : isInternalURL(data.url)
+                  ? // Backwards compat in the case that the block is storing the full server URL
+                    (() => {
+                      if (data.size === 'l')
+                        return `${flattenToAppURL(data.url)}/@@images/image`;
+                      if (data.size === 'm')
+                        return `${flattenToAppURL(
+                          data.url,
+                        )}/@@images/image/preview`;
+                      if (data.size === 's')
+                        return `${flattenToAppURL(
+                          data.url,
+                        )}/@@images/image/mini`;
+                      return `${flattenToAppURL(data.url)}/@@images/image`;
+                    })()
+                  : data.url
+              }
+              sizes={config.blocks.blocksConfig.image.getSizes(data)}
+              alt={data.alt || ''}
+              loading="lazy"
+              responsive={true}
+            />
+            <Caption
+              title={data.title}
+              description={data.description}
+              credit={data.credit?.data}
+              downloadFilename={data.title}
+              downloadHref={
+                data.allow_image_download &&
+                `${flattenToAppURL(data.url)}/${
+                  data.image_scales?.image[0].scales.fullscreen ||
+                  data.image_scales?.image[0].download
+                }`
+              }
+            />
+            {/* // END CUSTOMIZATION - Added `figure` tag */}
+          </figure>
+        ) : (
+          <div>
+            {this.props.editable && (
+              <Dropzone
+                noClick
+                onDrop={this.onDrop}
+                onDragEnter={this.onDragEnter}
+                onDragLeave={this.onDragLeave}
+                className="dropzone"
+              >
+                {({ getRootProps, getInputProps }) => (
+                  <div {...getRootProps()}>
+                    <Message>
+                      {this.state.dragging && <Dimmer active></Dimmer>}
+                      {this.state.uploading && (
+                        <Dimmer active>
+                          <Loader indeterminate>
+                            {this.props.intl.formatMessage(
+                              messages.uploadingImage,
+                            )}
+                          </Loader>
+                        </Dimmer>
+                      )}
+                      <div className="no-image-wrapper">
+                        <img src={imageBlockSVG} alt="" />
+                        <div className="toolbar-inner">
+                          <Button.Group>
+                            <Button
+                              basic
+                              icon
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                e.preventDefault();
+                                this.props.openObjectBrowser({
+                                  onSelectItem: (
+                                    url,
+                                    { title, image_field, image_scales },
+                                  ) => {
+                                    this.props.onChangeBlock(this.props.block, {
+                                      ...this.props.data,
+                                      url,
+                                      image_field,
+                                      image_scales,
+                                      alt: this.props.data.alt || title || '',
+                                    });
+                                  },
+                                });
+                              }}
+                            >
+                              <Icon name={navTreeSVG} size="24px" />
+                            </Button>
+                          </Button.Group>
+                          <Button.Group>
+                            <label className="ui button basic icon">
+                              <Icon name={uploadSVG} size="24px" />
+                              <input
+                                {...getInputProps({
+                                  type: 'file',
+                                  onChange: this.onUploadImage,
+                                  style: { display: 'none' },
+                                })}
+                              />
+                            </label>
+                          </Button.Group>
+                          <Input
+                            onKeyDown={this.onKeyDownVariantMenuForm}
+                            onChange={this.onChangeUrl}
+                            placeholder={placeholder}
+                            value={this.state.url}
+                            onClick={(e) => {
+                              e.target.focus();
+                            }}
+                            onFocus={(e) => {
+                              this.props.onSelectBlock(this.props.id);
+                            }}
+                          />
+                          {this.state.url && (
+                            <Button.Group>
+                              <Button
+                                basic
+                                className="cancel"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  this.setState({ url: '' });
+                                }}
+                              >
+                                <Icon name={clearSVG} size="30px" />
+                              </Button>
+                            </Button.Group>
+                          )}
+                          <Button.Group>
+                            <Button
+                              basic
+                              primary
+                              disabled={!this.state.url}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                this.onSubmitUrl();
+                              }}
+                            >
+                              <Icon name={aheadSVG} size="30px" />
+                            </Button>
+                          </Button.Group>
+                        </div>
+                      </div>
+                    </Message>
+                  </div>
+                )}
+              </Dropzone>
+            )}
+          </div>
+        )}
+        <SidebarPortal selected={this.props.selected}>
+          <ImageSidebar {...this.props} />
+        </SidebarPortal>
+      </div>
+    );
+  }
+}
+
+export default compose(
+  injectIntl,
+  withBlockExtensions,
+  connect(
+    (state, ownProps) => ({
+      request: state.content.subrequests[ownProps.block] || {},
+      content: state.content.subrequests[ownProps.block]?.data,
+    }),
+    { createContent },
+  ),
+)(Edit);

--- a/src/components/Blocks/Image/Edit.jsx
+++ b/src/components/Blocks/Image/Edit.jsx
@@ -177,8 +177,6 @@ class Edit extends Component {
     this.props.onChangeBlock(this.props.block, {
       ...this.props.data,
       url: flattenToAppURL(this.state.url),
-      image_field: undefined,
-      image_scales: undefined,
     });
   };
 
@@ -248,11 +246,12 @@ class Edit extends Component {
    * @returns {string} Markup for the component.
    */
   render() {
-    const { data } = this.props;
     const Image = config.getComponent({ name: 'Image' }).component;
+    const { block, data, onChangeBlock } = this.props;
     const placeholder =
       this.props.data.placeholder ||
       this.props.intl.formatMessage(messages.ImageBlockInputPlaceholder);
+    const dataAdapter = this.props.blocksConfig[data['@type']].dataAdapter;
 
     return (
       <div
@@ -328,15 +327,7 @@ class Edit extends Component {
             <Caption
               title={data.title}
               description={data.description}
-              credit={data.credit?.data}
-              downloadFilename={data.title}
-              downloadHref={
-                data.allow_image_download &&
-                `${flattenToAppURL(data.url)}/${
-                  data.image_scales?.image[0].scales.fullscreen ||
-                  data.image_scales?.image[0].download
-                }`
-              }
+              credit={data?.copyright_and_sources ?? data.credit?.data}
             />
             {/* // END CUSTOMIZATION - Added `figure` tag */}
           </figure>
@@ -374,16 +365,14 @@ class Edit extends Component {
                                 e.stopPropagation();
                                 e.preventDefault();
                                 this.props.openObjectBrowser({
-                                  onSelectItem: (
-                                    url,
-                                    { title, image_field, image_scales },
-                                  ) => {
-                                    this.props.onChangeBlock(this.props.block, {
-                                      ...this.props.data,
-                                      url,
-                                      image_field,
-                                      image_scales,
-                                      alt: this.props.data.alt || title || '',
+                                  onSelectItem: (url, item) => {
+                                    dataAdapter({
+                                      block,
+                                      data,
+                                      onChangeBlock,
+                                      id: 'url',
+                                      value: url,
+                                      item,
                                     });
                                   },
                                 });

--- a/src/components/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/Blocks/Image/ImageSidebar.jsx
@@ -28,13 +28,15 @@ const ImageSidebar = (props) => {
             basic
             disabled={!data.url}
             onClick={() => {
-              onChangeBlock(block, {
-                ...data,
-                url: undefined,
-                image_scales: undefined,
-                image_field: undefined,
-                alt: data.url.title === data.alt ? undefined : data.alt,
+              // START CUSTOMIZATION
+              dataAdapter({
+                block,
+                data,
+                id: 'url',
+                onChangeBlock,
+                value: null,
               });
+              // END CUSTOMIZATION
             }}
           >
             <Icon name={trashSVG} size="24px" color="red" />

--- a/src/components/Blocks/Image/ImageSidebar.jsx
+++ b/src/components/Blocks/Image/ImageSidebar.jsx
@@ -1,0 +1,128 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Segment, Button } from 'semantic-ui-react';
+import { useIntl, FormattedMessage, defineMessages } from 'react-intl';
+import { flattenToAppURL, isInternalURL } from '@plone/volto/helpers';
+import { BlockDataForm, Icon, Image } from '@plone/volto/components';
+import { ImageSchema } from '@plone/volto/components/manage/Blocks/Image/schema';
+import imageSVG from '@plone/volto/icons/image.svg';
+import trashSVG from '@plone/volto/icons/delete.svg';
+
+const ImageSidebar = (props) => {
+  const { blocksConfig, data, block, onChangeBlock } = props;
+  const intl = useIntl();
+  const schema = ImageSchema({ formData: data, intl });
+  // START CUSTOMIZATION
+  const dataAdapter = blocksConfig[data['@type']].dataAdapter;
+  // END CUSTOMIZATION
+
+  return (
+    <>
+      <header className="header pulled">
+        <h2>
+          <FormattedMessage id="Image" defaultMessage="Image" />
+        </h2>
+        <Button.Group>
+          <Button
+            title={intl.formatMessage(messages.clear)}
+            basic
+            disabled={!data.url}
+            onClick={() => {
+              onChangeBlock(block, {
+                ...data,
+                url: undefined,
+                image_scales: undefined,
+                image_field: undefined,
+                alt: data.url.title === data.alt ? undefined : data.alt,
+              });
+            }}
+          >
+            <Icon name={trashSVG} size="24px" color="red" />
+          </Button>
+        </Button.Group>
+      </header>
+
+      <Segment
+        className="sidebar-metadata-container image-sidebar"
+        secondary
+        attached
+      >
+        {data.url ? (
+          <>
+            <div>{(data.url?.['@id'] ?? data.url).split('/').slice(-1)[0]}</div>
+            <Image
+              item={
+                data.image_scales
+                  ? {
+                      '@id': data.url,
+                      image_field: data.image_field,
+                      image_scales: data.image_scales,
+                    }
+                  : undefined
+              }
+              src={
+                data.image_scales
+                  ? undefined
+                  : isInternalURL(data.url)
+                  ? // Backwards compat in the case that the block is storing the full server URL
+                    `${flattenToAppURL(data.url)}/@@images/image/preview`
+                  : data.url
+              }
+              sizes="188px"
+              alt={intl.formatMessage(messages.preview)}
+              loading="lazy"
+              responsive={true}
+              style={{ width: '50%' }}
+            />
+          </>
+        ) : (
+          <>
+            <FormattedMessage
+              id="No image selected"
+              defaultMessage="No image selected"
+            />
+            <Icon name={imageSVG} size="100px" color="#b8c6c8" />
+          </>
+        )}
+      </Segment>
+      <BlockDataForm
+        schema={schema}
+        title={schema.title}
+        // START CUSTOMIZATION
+        onChangeField={(id, value) => {
+          dataAdapter({
+            block,
+            data,
+            id,
+            onChangeBlock,
+            value,
+          });
+        }}
+        // END CUSTOMIZATION
+        onChangeBlock={onChangeBlock}
+        formData={data}
+        block={block}
+        blocksConfig={blocksConfig}
+      />
+    </>
+  );
+};
+
+ImageSidebar.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+  block: PropTypes.string.isRequired,
+  onChangeBlock: PropTypes.func.isRequired,
+};
+
+export default ImageSidebar;
+
+const messages = defineMessages({
+  preview: {
+    id: 'image_block_preview',
+    defaultMessage: 'Image preview',
+  },
+  clear: {
+    id: 'image_block_clear',
+    defaultMessage: 'Clear image',
+  },
+});

--- a/src/components/Blocks/Image/View.jsx
+++ b/src/components/Blocks/Image/View.jsx
@@ -1,0 +1,157 @@
+/**
+ * View image block.
+ * @module components/manage/Blocks/Image/View
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { UniversalLink } from '@plone/volto/components';
+import cx from 'classnames';
+import Caption from '../../Caption/Caption';
+import {
+  flattenToAppURL,
+  isInternalURL,
+  withBlockExtensions,
+} from '@plone/volto/helpers';
+import config from '@plone/volto/registry';
+
+/**
+ * View image block class.
+ * @class View
+ * @extends Component
+ */
+export const ImageView = ({ className, data, detached, properties }) => {
+  let href;
+  if (data.href?.length > 0) {
+    if (typeof data.href === 'object') {
+      href = data.href[0]['@id'];
+    } else if (typeof data.href === 'string') {
+      // just to catch cases where a string might be supplied
+      href = data.href;
+    }
+  }
+
+  const Image = config.getComponent({ name: 'Image' }).component;
+
+  return (
+    <div
+      className={cx(
+        'block image align',
+        {
+          center: !Boolean(data.align),
+          detached,
+        },
+        data.align,
+        className,
+      )}
+    >
+      {data.url && (
+        <>
+          {(() => {
+            const image = (
+              <figure
+                className={cx(
+                  'figure',
+                  {
+                    center: !Boolean(data.align),
+                    detached,
+                  },
+                  data.align,
+                  {
+                    // START CUSTOMIZATION
+                    // 'full-width': data.align === 'full',
+                    // END CUSTOMIZATION
+                    large: data.size === 'l',
+                    medium: data.size === 'm' || !data.size,
+                    small: data.size === 's',
+                  },
+                )}
+              >
+                <Image
+                  // Removed for now
+                  // className={cx({
+                  //   'full-width': data.align === 'full',
+                  //   large: data.size === 'l',
+                  //   medium: data.size === 'm',
+                  //   small: data.size === 's',
+                  // })}
+                  item={
+                    data.image_scales
+                      ? {
+                          '@id': data.url,
+                          image_field: data.image_field,
+                          image_scales: data.image_scales,
+                        }
+                      : undefined
+                  }
+                  src={
+                    data.image_scales
+                      ? undefined
+                      : isInternalURL(data.url)
+                      ? // Backwards compat in the case that the block is storing the full server URL
+                        (() => {
+                          if (data.size === 'l')
+                            return `${flattenToAppURL(
+                              data.url,
+                            )}/@@images/image`;
+                          if (data.size === 'm')
+                            return `${flattenToAppURL(
+                              data.url,
+                            )}/@@images/image/preview`;
+                          if (data.size === 's')
+                            return `${flattenToAppURL(
+                              data.url,
+                            )}/@@images/image/mini`;
+                          return `${flattenToAppURL(data.url)}/@@images/image`;
+                        })()
+                      : data.url
+                  }
+                  sizes={config.blocks.blocksConfig.image.getSizes(data)}
+                  alt={data.alt || ''}
+                  loading="lazy"
+                  responsive={true}
+                />
+                <Caption
+                  title={data.title}
+                  description={data.description}
+                  credit={data.credit?.data}
+                  downloadFilename={data.title}
+                  downloadHref={
+                    data.allow_image_download &&
+                    `${flattenToAppURL(data.url)}/${
+                      data.image_scales?.image[0].scales?.fullscreen
+                        ?.download || data.image_scales?.image[0].download
+                    }`
+                  }
+                />
+              </figure>
+            );
+            if (href) {
+              return (
+                <UniversalLink
+                  href={href}
+                  openLinkInNewTab={data.openLinkInNewTab}
+                >
+                  {image}
+                </UniversalLink>
+              );
+            } else {
+              return image;
+            }
+          })()}
+        </>
+      )}
+    </div>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+ImageView.propTypes = {
+  data: PropTypes.objectOf(PropTypes.any).isRequired,
+};
+
+export default withBlockExtensions(ImageView);

--- a/src/components/Blocks/Image/View.jsx
+++ b/src/components/Blocks/Image/View.jsx
@@ -114,15 +114,7 @@ export const ImageView = ({ className, data, detached, properties }) => {
                 <Caption
                   title={data.title}
                   description={data.description}
-                  credit={data.credit?.data}
-                  downloadFilename={data.title}
-                  downloadHref={
-                    data.allow_image_download &&
-                    `${flattenToAppURL(data.url)}/${
-                      data.image_scales?.image[0].scales?.fullscreen
-                        ?.download || data.image_scales?.image[0].download
-                    }`
-                  }
+                  credit={data?.copyright_and_sources ?? data.credit?.data}
                 />
               </figure>
             );

--- a/src/components/Blocks/Image/adapter.js
+++ b/src/components/Blocks/Image/adapter.js
@@ -1,0 +1,52 @@
+export const ImageBlockDataAdapter = ({
+  block,
+  data,
+  id,
+  item,
+  onChangeBlock,
+  value,
+}) => {
+  const SIZEMAP = {
+    l: 'large',
+    m: 'medium',
+    s: 'small',
+  };
+
+  let dataSaved = {
+    ...data,
+    [id]: value,
+  };
+
+  if (id === 'align' && !(value === 'left' || value === 'right')) {
+    if (data.size !== 'l') {
+      dataSaved = {
+        ...dataSaved,
+        size: 'l',
+        styles: {
+          ...dataSaved.styles,
+          'size:noprefix': SIZEMAP['l'],
+        },
+      };
+    }
+  }
+
+  if (id === 'size') {
+    dataSaved = {
+      ...dataSaved,
+      styles: {
+        ...dataSaved.styles,
+        'size:noprefix': SIZEMAP[value],
+      },
+    };
+  }
+
+  if (id === 'url') {
+    dataSaved = {
+      ...dataSaved,
+      credit: { data: item?.credit },
+      description: item?.Description,
+      title: item?.Title,
+    };
+  }
+  onChangeBlock(block, dataSaved);
+};

--- a/src/components/Blocks/Image/adapter.js
+++ b/src/components/Blocks/Image/adapter.js
@@ -41,12 +41,25 @@ export const ImageBlockDataAdapter = ({
   }
 
   if (id === 'url') {
-    dataSaved = {
-      ...dataSaved,
-      credit: { data: item?.credit },
-      description: item?.Description,
-      title: item?.Title,
-    };
+    if (value) {
+      dataSaved = {
+        ...dataSaved,
+        credit: { data: item?.credit },
+        description: item?.Description,
+        title: item?.Title,
+        image_field: item?.image_field,
+        image_scales: item?.image_scales,
+      };
+    } else {
+      [
+        'alt',
+        'credit',
+        'description',
+        'image_scales',
+        'image_field',
+        'title',
+      ].forEach((id) => delete dataSaved[id]);
+    }
   }
   onChangeBlock(block, dataSaved);
 };

--- a/src/components/Blocks/Image/schema.js
+++ b/src/components/Blocks/Image/schema.js
@@ -1,0 +1,44 @@
+import { defineMessages } from 'react-intl';
+import { insertInArray } from '@plone/volto/helpers/Utils/Utils';
+
+const messages = defineMessages({
+  Description: {
+    id: 'Description',
+    defaultMessage: 'Description',
+  },
+  Title: {
+    id: 'Title',
+    defaultMessage: 'Title',
+  },
+});
+
+export const imageBlockSchemaEnhancer = ({ formData, schema, intl }) => {
+  if (formData.url) {
+    schema.fieldsets[0].fields = insertInArray(
+      schema.fieldsets[0].fields,
+      'description',
+      1,
+    );
+    schema.fieldsets[0].fields = insertInArray(
+      schema.fieldsets[0].fields,
+      'title',
+      1,
+    );
+    schema.properties.description = {
+      title: intl.formatMessage(messages.Description),
+      widget: 'textarea',
+    };
+    schema.properties.title = {
+      title: intl.formatMessage(messages.Title),
+    };
+  }
+  schema.properties.align.default = 'center';
+  schema.properties.align.actions = ['left', 'right', 'center', 'wide', 'full'];
+  schema.properties.size.default = 'l';
+  schema.properties.size.disabled =
+    formData.align === 'full' ||
+    formData.align === 'wide' ||
+    formData.align === 'center';
+
+  return schema;
+};

--- a/src/components/Caption/Caption.jsx
+++ b/src/components/Caption/Caption.jsx
@@ -1,0 +1,75 @@
+/**
+ * Image/video caption component.
+ * @module components/Image/Caption
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { UniversalLink } from '@plone/volto/components';
+
+/**
+ * Image/video caption component class.
+ * @function Caption
+ * @params {string} as HTML tag used to wrap the caption.
+ * @params {string} title Image title.
+ * @params {string} description Image description.
+ * @params {object} imageNumber Image number.
+ * @params {object} credit Credit rich text.
+ * @params {bool} downloadHref Show download link.
+ * @returns {string} Markup of the component.
+ */
+const Caption = ({
+  as = 'figcaption',
+  title,
+  description,
+  imageNumber = '',
+  credit,
+  downloadHref,
+  downloadFilename,
+}) => {
+  const As = as;
+
+  return (
+    <As>
+      {title && <div className="title">{title}</div>}
+      {description && (
+        <div className="description">
+          {description.split('\n').map((line, index) => (
+            <div key={index}>{line || '\u00A0'}</div>
+          ))}
+        </div>
+      )}
+      <div className="credits">
+        {credit && (
+          <div>
+            {imageNumber}
+            Credit: {credit}
+          </div>
+        )}
+        {downloadHref && (
+          <UniversalLink
+            href={downloadHref}
+            download={true}
+            downloadFilename={downloadFilename}
+            tabIndex="0"
+          >
+            Download
+          </UniversalLink>
+        )}
+      </div>
+    </As>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+Caption.propTypes = {
+  allow_image_download: PropTypes.bool,
+  credit: PropTypes.string,
+  title: PropTypes.string,
+  description: PropTypes.string,
+};
+
+export default Caption;

--- a/src/components/Caption/Caption.jsx
+++ b/src/components/Caption/Caption.jsx
@@ -4,7 +4,6 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { UniversalLink } from '@plone/volto/components';
 
 /**
  * Image/video caption component class.
@@ -12,20 +11,10 @@ import { UniversalLink } from '@plone/volto/components';
  * @params {string} as HTML tag used to wrap the caption.
  * @params {string} title Image title.
  * @params {string} description Image description.
- * @params {object} imageNumber Image number.
- * @params {object} credit Credit rich text.
- * @params {bool} downloadHref Show download link.
+ * @params {object} credit Credit text.
  * @returns {string} Markup of the component.
  */
-const Caption = ({
-  as = 'figcaption',
-  title,
-  description,
-  imageNumber = '',
-  credit,
-  downloadHref,
-  downloadFilename,
-}) => {
+const Caption = ({ as = 'figcaption', title, description, credit }) => {
   const As = as;
 
   return (
@@ -38,24 +27,7 @@ const Caption = ({
           ))}
         </div>
       )}
-      <div className="credits">
-        {credit && (
-          <div>
-            {imageNumber}
-            Credit: {credit}
-          </div>
-        )}
-        {downloadHref && (
-          <UniversalLink
-            href={downloadHref}
-            download={true}
-            downloadFilename={downloadFilename}
-            tabIndex="0"
-          >
-            Download
-          </UniversalLink>
-        )}
-      </div>
+      {credit && <div className="credits">{credit}</div>}
     </As>
   );
 };
@@ -66,7 +38,6 @@ const Caption = ({
  * @static
  */
 Caption.propTypes = {
-  allow_image_download: PropTypes.bool,
   credit: PropTypes.string,
   title: PropTypes.string,
   description: PropTypes.string,

--- a/src/components/Theme/ImageView.jsx
+++ b/src/components/Theme/ImageView.jsx
@@ -7,8 +7,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Container as SemanticContainer } from 'semantic-ui-react';
 
-import { flattenToAppURL } from '@plone/volto/helpers';
-
 // BEGIN CUSTOMIZATION
 import config from '@plone/volto/registry';
 import Caption from '../Caption/Caption';
@@ -32,36 +30,11 @@ const ImageView = ({ content }) => {
       <h1 className="documentFirstHeading">{content.title}</h1>
       {content?.image?.download && (
         <figure>
-          <Image
-            item={content}
-            imageField="image"
-            alt={content.title}
-            responsive={true}
-          />
-          {/* <Image
-            width={content.image?.width}
-            height={content.image?.height}
-            alt={content.alt_tag || ''}
-            src={content.image}
-            blurhash={content.blurhash}
-            blurhashOptions={{
-              // override default width 100%
-              style: {},
-            }}
-            style={{ maxWidth: '100%', height: 'auto' }}
-          /> */}
+          <Image item={content} imageField="image" alt="" responsive={true} />
           <Caption
             title={content.title}
             description={content.description}
-            credit={content.credit?.data}
-            downloadFilename={content.title}
-            downloadHref={
-              content.allow_image_download &&
-              flattenToAppURL(
-                content.image.scales.fullscreen?.download ||
-                  content.image.download,
-              )
-            }
+            credit={content?.copyright_and_sources || content.credit?.data}
           />
         </figure>
       )}
@@ -87,11 +60,10 @@ ImageView.propTypes = {
       }),
     }),
     // BEGIN CUSTOMIZATION
-    allow_image_download: PropTypes.bool,
+    copyright_and_sources: PropTypes.string,
     credit: PropTypes.shape({
       data: PropTypes.string,
     }),
-    alt_tag: PropTypes.string,
     // END CUSTOMIZATION
   }).isRequired,
 };

--- a/src/components/Theme/ImageView.jsx
+++ b/src/components/Theme/ImageView.jsx
@@ -11,7 +11,7 @@ import { flattenToAppURL } from '@plone/volto/helpers';
 
 // BEGIN CUSTOMIZATION
 import config from '@plone/volto/registry';
-import Caption from '@kitconcept/volto-image-block/components/Caption/Caption';
+import Caption from '../Caption/Caption';
 
 // END CUSTOMIZATION
 
@@ -25,6 +25,7 @@ const ImageView = ({ content }) => {
   const Image = config.getComponent('Image').component;
   const Container =
     config.getComponent({ name: 'Container' }).component || SemanticContainer;
+
   return (
     <Container id="page-document" className="view-wrapper image-view">
       {/* BEGIN CUSTOMIZATION */}
@@ -32,6 +33,12 @@ const ImageView = ({ content }) => {
       {content?.image?.download && (
         <figure>
           <Image
+            item={content}
+            imageField="image"
+            alt={content.title}
+            responsive={true}
+          />
+          {/* <Image
             width={content.image?.width}
             height={content.image?.height}
             alt={content.alt_tag || ''}
@@ -42,7 +49,7 @@ const ImageView = ({ content }) => {
               style: {},
             }}
             style={{ maxWidth: '100%', height: 'auto' }}
-          />
+          /> */}
           <Caption
             title={content.title}
             description={content.description}

--- a/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
@@ -1,0 +1,9 @@
+/**
+ * OVERRIDE Edit.jsx
+ * REASON: This theme introduces the concept of "Caption" and uses `figure`
+ * tag for the image.
+ */
+
+import ImageEdit from '../../../../../../components/Blocks/Image/Edit';
+
+export default ImageEdit;

--- a/src/customizations/volto/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -1,0 +1,9 @@
+/**
+ * OVERRIDE ImageSidebar.jsx
+ * REASON: There are some specific behavior that we want to enforce to the sizes
+ * and alignment settings
+ */
+
+import ImageSidebar from '../../../../../../components/Blocks/Image/ImageSidebar';
+
+export default ImageSidebar;

--- a/src/customizations/volto/components/manage/Blocks/Image/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Image/View.jsx
@@ -1,0 +1,9 @@
+/**
+ * OVERRIDE View.jsx
+ * REASON: This theme introduces the concept of "Caption" and uses `figure`
+ * tag for the image.
+ */
+
+import ImageView from '../../../../../../components/Blocks/Image/View';
+
+export default ImageView;

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,9 @@ import TopSideFacets from './components/Blocks/Search/TopSideFacets';
 import GridListingBlockTemplate from './components/Blocks/Listing/GridTemplate';
 import { ButtonStylingSchema } from './components/Blocks/Button/schema';
 
+import { imageBlockSchemaEnhancer } from './components/Blocks/Image/schema';
+import { ImageBlockDataAdapter } from './components/Blocks/Image/adapter';
+
 import { AccordionSchemaEnhancer } from './components/Blocks/Accordion/schema';
 
 import gridSVG from './icons/block_icn_grid.svg';
@@ -253,6 +256,12 @@ const applyConfig = (config) => {
       colors: BG_COLORS,
     };
   }
+
+  config.blocks.blocksConfig.image = {
+    ...config.blocks.blocksConfig.image,
+    schemaEnhancer: imageBlockSchemaEnhancer,
+    dataAdapter: ImageBlockDataAdapter,
+  };
 
   config.views.contentTypesViews.Event = EventView;
 

--- a/src/theme/blocks/_grid.scss
+++ b/src/theme/blocks/_grid.scss
@@ -13,6 +13,11 @@
     }
   }
 
+  // Override the Image component `aspect-ratio`
+  .block.image img {
+    aspect-ratio: $aspect-ratio !important;
+  }
+
   .block.teaser {
     margin-bottom: 0;
     background-color: $lightgrey;

--- a/src/theme/blocks/_image.scss
+++ b/src/theme/blocks/_image.scss
@@ -43,7 +43,7 @@ figure {
     img {
       width: 100% !important;
       height: auto;
-      aspect-ratio: $aspect-ratio;
+      aspect-ratio: $aspect-ratio !important;
     }
 
     &.right {

--- a/src/theme/blocks/_listing.scss
+++ b/src/theme/blocks/_listing.scss
@@ -56,7 +56,7 @@
       img {
         width: 220px;
         height: min-content;
-        aspect-ratio: $aspect-ratio;
+        aspect-ratio: $aspect-ratio !important;
       }
       h3 {
         margin-bottom: 40px !important;

--- a/src/theme/blocks/_teaser.scss
+++ b/src/theme/blocks/_teaser.scss
@@ -1,3 +1,8 @@
+// Override the Image component `aspect-ratio`
+.teaser-item .image-wrapper img {
+  aspect-ratio: $aspect-ratio !important;
+}
+
 // Block Teaser Standalone
 #page-document .block.teaser {
   @include vertical-space-teaser();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1660,11 +1660,10 @@ __metadata:
     "@kitconcept/volto-button-block": ^2.3.1
     "@kitconcept/volto-dsgvo-banner": ^1.3.0
     "@kitconcept/volto-heading-block": ^2.2.0
-    "@kitconcept/volto-image-block": ^1.0.3
     "@kitconcept/volto-introduction-block": ^1.0.0
     "@kitconcept/volto-separator-block": ^3.2.2
     "@kitconcept/volto-slider-block": ^4.2.0
-    "@plone/volto": ^17.0.0-alpha.20
+    "@plone/volto": ^17.0.0-alpha.21
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
We have to be careful with this one, but this is the initial work needed.

The gist: I think the DLR image component is overengineered and not usable, and the DX is very poor. I still cannot make it work and instantiate it at the first shot. I think we should move to use the new image component in core. (Volto 17a21). The DX and the simplicity of it is far better.

The only downside is that the core one does not use `blurhash`. Any other opinions?

**NOTE for this August (while I'm on holidays)**: You can update Volto to latest without this, the image component in `volto-image-block` will take over. Up to you to merge this and follow up, an exhaustive QA should be done on all places where this is used. 
