### PR TITLE
Fix alt description font-size in image block sidebar.

### DIFF
--- a/news/217.bugfix
+++ b/news/217.bugfix
@@ -1,0 +1,1 @@
+Fix font-size of alt text description. @iFlameing

--- a/src/theme/blocks/_image.scss
+++ b/src/theme/blocks/_image.scss
@@ -330,3 +330,13 @@ figcaption {
     }
   }
 }
+
+.ui.form {
+  p.help {
+    @include marginal-description();
+    a {
+      @include marginal-description();
+      text-decoration: underline;
+    }
+  }
+}


### PR DESCRIPTION
<img width="280" alt="Screenshot 2023-08-11 at 5 36 10 PM" src="https://github.com/kitconcept/volto-light-theme/assets/33936987/6c31b60b-9467-4626-af05-a1702d617632">
