### PR TITLE
Fix form inputs height, transfer the height property to the parent .ui.input instead of the input itself, which behaves wrong.

### DIFF
--- a/news/234.bugfix
+++ b/news/234.bugfix
@@ -1,0 +1,1 @@
+Fix form inputs height, transfer the height property to the parent .ui.input instead of the input itself, which behaves wrong. @sneridagh

--- a/src/theme/_typography.scss
+++ b/src/theme/_typography.scss
@@ -3,10 +3,12 @@
 // Accents are cut off on top,
 // see https://gitlab.dlr.de/internet-cms/cms-plone/dlr-internet/-/issues/860
 
-#sidebar input,
-#toolbar input {
+#sidebar .inline.field.text input,
+#toolbar .inline.field.text input {
   // needed with Metropolis font
-  line-height: 4;
+  // line-height: 4; <- This fix was addressing it in a wrong way. Nothing wrong with the font.
+  font-size: 16px;
+  line-height: 22px;
 }
 
 // Backport to Volto - nov 2020

--- a/src/theme/collections/form.overrides
+++ b/src/theme/collections/form.overrides
@@ -1,0 +1,19 @@
+.ui.form .ui.input input:not([type]),
+.ui.form .ui.input input[type='date'],
+.ui.form .ui.input input[type='datetime-local'],
+.ui.form .ui.input input[type='email'],
+.ui.form .ui.input input[type='number'],
+.ui.form .ui.input input[type='password'],
+.ui.form .ui.input input[type='search'],
+.ui.form .ui.input input[type='tel'],
+.ui.form .ui.input input[type='time'],
+.ui.form .ui.input input[type='text'],
+.ui.form .ui.input input[type='file'],
+.ui.form .ui.input input[type='url'],
+.ui.form textarea {
+  height: initial;
+}
+
+.ui.form .ui.input {
+  height: 60px;
+}


### PR DESCRIPTION
This might be interesting for Volto itself, after testing.