### PR TITLE
remove huge margins on listing blocks without headlines.

### DIFF
--- a/news/239.bugfix
+++ b/news/239.bugfix
@@ -1,0 +1,1 @@
+Remove too large margins on listing blocks @steffenri

--- a/src/theme/blocks/_listing.scss
+++ b/src/theme/blocks/_listing.scss
@@ -208,10 +208,6 @@
     }
   }
 
-  &:not(.has--headline) {
-    margin-top: 200px;
-  }
-
   .documentFirstHeading
     + &.previous--has--same--backgroundColor:not(.has--headline) {
     margin-top: 0;


### PR DESCRIPTION
example: https://light-theme.kitconcept.io/vertical-spacing/listing-and-listing

