### PR TITLE
Update contentMetadataTagsImageField settings to use preview_image field(#274)

### DIFF
--- a/news/274.bugfix
+++ b/news/274.bugfix
@@ -1,0 +1,1 @@
+Update contentMetadataTagsImageField settings to use preview_image field.  @iRohitSingh

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ const applyConfig = (config) => {
   config.settings.navDepth = 3;
   config.settings.enableFatMenu = true;
   config.settings.slate.useLinkedHeadings = false;
+  config.settings.contentMetadataTagsImageField = 'preview_image';
 
   // Remove Hero Block
   config.blocks.blocksConfig.hero.restricted = true;


### PR DESCRIPTION
Fix #274 

<img width="1470" alt="Screenshot 2023-12-01 at 7 54 13 PM" src="https://github.com/kitconcept/volto-light-theme/assets/61353484/6c7fbe54-19ee-476e-b319-4dfec5a37117">
