### PR TITLE
Update typography patterns to use unitless line-heights

### DIFF
--- a/news/296.feature
+++ b/news/296.feature
@@ -1,0 +1,1 @@
+Update typography patterns to use unitless line-heights @danalvrz

--- a/src/theme/_typo-custom.scss
+++ b/src/theme/_typo-custom.scss
@@ -60,6 +60,7 @@ em span span {
 #page-document {
   blockquote {
     padding: 18px 40px;
+    @include blockquote();
   }
 }
 

--- a/src/theme/_variables.scss
+++ b/src/theme/_variables.scss
@@ -346,6 +346,7 @@ $line-heights: (
 
 @mixin external-link-icon() {
   display: inline;
-  content: '\a0'url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='external-link-alt' class='svg-inline--fa fa-external-link-alt fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' width='11' height='11' %3E%3Cpath fill='%23007EB1' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E");
+  content: '\a0'
+    url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='external-link-alt' class='svg-inline--fa fa-external-link-alt fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' width='11' height='11' %3E%3Cpath fill='%23007EB1' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E");
   white-space: nowrap;
 }

--- a/src/theme/_variables.scss
+++ b/src/theme/_variables.scss
@@ -218,15 +218,15 @@ $font-sizes: (
 );
 
 $line-heights: (
-  xs: 16px,
-  s: 18px,
-  m: 24px,
-  l: 30px,
-  xl: 33px,
-  2xl: 36px,
-  3xl: 42px,
-  4xl: 48px,
-  5xl: 56px,
+  2xs: 1.1428,
+  xs: 1.1667,
+  s: 1.2,
+  m: 1.25,
+  l: 1.2727,
+  xl: 1.2857,
+  2xl: 1.3333,
+  3xl: 1.375,
+  4xl: 1.4285,
 );
 
 @mixin add($property, $value) {
@@ -242,105 +242,110 @@ $line-heights: (
 // Patterns
 @mixin body-text() {
   @include add(size, s);
-  @include add(height, m);
+  @include add(height, 2xl);
   @include add(weight, light);
 }
 
 @mixin body-text-bold() {
   @include add(size, s);
-  @include add(height, m);
+  @include add(height, 2xl);
   @include add(weight, bold);
 }
 
 @mixin page-title() {
   @include add(size, 5xl);
-  @include add(height, 5xl);
+  @include add(height, xs);
   @include add(weight, bold);
 
   @container (max-width: #{$largest-mobile-screen}) {
     @include add(size, 4xl);
-    @include add(height, 4xl);
+    @include add(height, 2xs);
   }
 }
 
 @mixin block-title() {
   @include add(size, 2xl);
-  @include add(height, 3xl);
+  @include add(height, l);
   @include add(weight, light);
 
   @container (max-width: #{$largest-mobile-screen}) {
     @include add(size, xl);
-    @include add(height, 2xl);
+    @include add(height, s);
   }
 }
 
 @mixin text-heading-h2() {
   @include add(size, xl);
-  @include add(height, 2xl);
+  @include add(height, s);
   @include add(weight, bold);
 }
 
 @mixin text-heading-h3() {
   @include add(size, l);
-  @include add(height, l);
+  @include add(height, m);
   @include add(weight, bold);
 }
 
 @mixin text-heading-h4() {
   @include add(size, s);
-  @include add(height, m);
+  @include add(height, 2xl);
   @include add(weight, bold);
 }
 
 @mixin introduction() {
   @include add(size, l);
-  @include add(height, xl);
+  @include add(height, 3xl);
   @include add(weight, light);
 
   @container (max-width: #{$largest-mobile-screen}) {
     @include add(size, m);
-    @include add(height, l);
+    @include add(height, 4xl);
   }
 }
 
 @mixin headtitle1() {
   @include add(size, xs);
-  @include add(height, s);
+  @include add(height, xl);
   @include add(weight, bold);
 }
 
 @mixin headtitle2() {
   @include add(size, 2xs);
-  @include add(height, xs);
+  @include add(height, 2xl);
   @include add(weight, bold);
 }
 
 @mixin highlight-title() {
   @include add(size, 3xl);
-  @include add(height, 4xl);
+  @include add(height, 2xl);
   @include add(weight, bold);
 
   @container (max-width: #{$largest-mobile-screen}) {
     @include add(size, 2xl);
-    @include add(height, 3xl);
+    @include add(height, l);
   }
 }
 
 @mixin marginal-title() {
   @include add(size, xs);
-  @include add(height, s);
+  @include add(height, xl);
   @include add(weight, bold);
 }
 
 @mixin marginal-description() {
   @include add(size, xs);
-  @include add(height, s);
+  @include add(height, xl);
+  @include add(weight, light);
+}
+
+@mixin blockquote() {
+  @include add(size, s);
+  @include add(height, 2xl);
   @include add(weight, light);
 }
 
 @mixin external-link-icon() {
   display: inline;
-  content: '\a0'
-    url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='external-link-alt' class='svg-inline--fa fa-external-link-alt fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' width='11' height='11' %3E%3Cpath fill='%23007EB1' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E");
+  content: '\a0'url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='external-link-alt' class='svg-inline--fa fa-external-link-alt fa-w-16' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' width='11' height='11' %3E%3Cpath fill='%23007EB1' d='M432,320H400a16,16,0,0,0-16,16V448H64V128H208a16,16,0,0,0,16-16V80a16,16,0,0,0-16-16H48A48,48,0,0,0,0,112V464a48,48,0,0,0,48,48H400a48,48,0,0,0,48-48V336A16,16,0,0,0,432,320ZM488,0h-128c-21.37,0-32.05,25.91-17,41l35.73,35.73L135,320.37a24,24,0,0,0,0,34L157.67,377a24,24,0,0,0,34,0L435.28,133.32,471,169c15,15,41,4.5,41-17V24A24,24,0,0,0,488,0Z'%3E%3C/path%3E%3C/svg%3E");
   white-space: nowrap;
 }


### PR DESCRIPTION
Fixes #273 

@sneridagh four decimals are the minimum to achieve the correct heights for some designs, but we could always round them if we don't like that. 

I also added a `blockquote()` mixin because I noticed the `blockquote` elements were using SemanticUI styles. As a result, their font size is now bigger, but in fact that is how it is specified on the design spreadsheet, we can always adjust it if needed.