### PR TITLE
Fix showing up uploaded logo from site controlpanel

### DIFF
--- a/news/291.bugfix
+++ b/news/291.bugfix
@@ -1,0 +1,1 @@
+Fix showing up uploaded logo from site controlpanel. @iFlameing

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -1,10 +1,12 @@
 // SemanticUI-free pre-@plone/components
+import { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import config from '@plone/volto/registry';
 import { UniversalLink } from '@plone/volto/components';
 import { toBackendLang } from '@plone/volto/helpers';
 import LogoImage from '@plone/volto/components/theme/Logo/Logo.svg';
+import { flattenToAppURL } from '@plone/volto/helpers';
 
 const messages = defineMessages({
   site: {
@@ -21,6 +23,7 @@ const Logo = () => {
   const { settings } = config;
   const lang = useSelector((state) => state.intl.locale);
   const intl = useIntl();
+  const site = useSelector((state) => state.site.data);
 
   return (
     <UniversalLink
@@ -28,7 +31,11 @@ const Logo = () => {
       title={intl.formatMessage(messages.site)}
     >
       <img
-        src={LogoImage}
+        src={
+          site['plone.site_logo']
+            ? flattenToAppURL(site['plone.site_logo'])
+            : LogoImage
+        }
         alt={intl.formatMessage(messages.plonesite)}
         title={intl.formatMessage(messages.plonesite)}
       />

--- a/src/components/Logo/Logo.jsx
+++ b/src/components/Logo/Logo.jsx
@@ -1,5 +1,4 @@
 // SemanticUI-free pre-@plone/components
-import { useEffect } from 'react';
 import { defineMessages, useIntl } from 'react-intl';
 import { useSelector } from 'react-redux';
 import config from '@plone/volto/registry';


### PR DESCRIPTION
@sneridagh If you upload a larger image, the logo will take full width and height of an image. What should be the maximum width and height for the logo image? I am thinking of something 250 and 150. I searched google and it is appropriate. 