### PR TITLE
Fix spacing between title and description in teaser block.(Breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,32 +9,34 @@
 
 ## Vision
 
-The Volto Light Theme main vision is to provide kitconcept a theme to build upon the projects to come after the release of Plone 6.
+The main vision of the Volto Light Theme is to serve as a foundation for kitconcept's future projects, following the release of Plone 6.
 
-It should contain all the feedback and success stories in UI/UX side that the company had during the last years projects.
+It contains the feedback from the company's last years projects and the success stories in the UI/UX side.
 
-It should also be future proof, so it has to be aligned with the upcoming Volto vision in terms of theming strategy decided by the Plone community.
+It aims to be future proof, so it has to be aligned with the upcoming Volto vision in terms of theming strategy decided by the Plone community.
 
 ![Volto-Light-Theme](https://github.com/kitconcept/volto-light-theme/raw/main/volto-light-theme.png)
 
-## Requirements
+## Requirements and specs
 
 ### It should not use any SemanticUI component or styling
 
 Volto will abandon SemanticUI as default design component system in the mid term, and we should be prepared for it.
 
-We will achieve that not using any SemanticUI component, nor any related styling (`.ui.XXX`) in our upcoming themes.
+We will achieve that by not using any SemanticUI component, nor any related styling (`.ui.XXX`) in our upcoming themes.
 
 The Volto strategy is:
 
-- To provide a very basic and structural Vanilla components to build upon theming and CMSUI as well.
-- These components will be based in a headless component system. The best positioned right now is [react-aria](https://react-spectrum.adobe.com/react-aria/).
-- The theming could be done using these basic components or dropping in the component system of the developer/integrator choice. The presence of Volto's component registry system could help for adapting, if required.
-- The CMSUI will be isolated from the theming because it will be extremely CSS specific, so leaks from theming-CMSUI won't happen.
+- Provide a very basic and structural Vanilla components to build upon theming and CMSUI as well (`@plone/components`)
+- These components will be based in a headless component system [React Aria Components](https://react-spectrum.adobe.com/react-aria/components.html)
+- Volto projects can be themed using `@plone/components` as baseline or use a complete different design or component system of the developer/integrator choice. The presence of Volto's component registry system could help for adapting, if required.
 
 #### Volto components `customizations` use case
 
-If possible, we will switch to SemanticUI-less components in case of they exist. Specially if the elements that we are customizing are clearly "theme" (eg. header/footer, etc). In the case of other Volto customizations that are not clear part of the theme (eg. Search block), it's fine to stick using what the original is using (SemanticUI). When Volto will make the switch in the future, we should then adapt all the customizations to match the one in the Volto core.
+If possible, we will switch to SemanticUI-less components when `@plone/components` is ready.
+Specially if the elements that we are customizing are clearly "theme" (eg. header/footer, etc).
+In the case of other Volto customizations that are not clear part of the theme (eg. Search block), it's fine to stick using what the original is using (SemanticUI).
+When Volto will make the switch in the future, we should then adapt all the customizations to match the one in the Volto core.
 The approach used is to use a proxy to a component of the `components` folder. This way it's easier to keep track of changes, and another add-on can customize again the light theme component, not the original Volto customization.
 
 ### It should use kitconcept's layout used in FZJ/DLR projects
@@ -55,9 +57,9 @@ Since the new container queries spec is out, we will be introducing it to the cu
 
 We will start organising the files in the root of `theme` folder, to differentiate from a normal "SemanticUI" theme. Take a look at the current state. We will follow this convention:
 
-- One less file per component/block
-- All less files loading are centralized in one main less file `custom.less` in this project, could be different in the future.
-- Vanilla headless components are named under `atoms` folder.
+- One file per component/block
+- Use the Volto theme facility using the SCSS scape hatch provided so other add-ons can hook to it.
+- The styling is centralized in `main.scss`, the rest of the files are loaded from there.
 
 ## Why a headless component system?
 
@@ -68,6 +70,8 @@ https://medium.com/@nirbenyair/headless-components-in-react-and-why-i-stopped-us
 This theme has the concept of block "grouping" given two consecutive blocks with the same styling block wrapper property `backgroundColor`. You have to add this property to your blocks in your blocks code. This add-on customizes `RenderBlocks.jsx` component in order to do so.
 
 The wrappers have the classnames `blocks-group-wrapper` and the name of the background color, eg. `grey`, defaulting to `transparent` if no `backgroundColor` property is set in the styling block wrapper in the block.
+
+**Disclaimer**: This might change in the near future, since we are developing a new integral Block Model for VLT and Volto.
 
 ### Vertical spacing rules
 
@@ -93,7 +97,7 @@ We use container queries when do care explicitly about how the styling is being 
 
 Reason: The container queries allow us to abstract the width from the sidebar and toolbar in edit mode, showing the content area as it will be in that size, in view mode.
 
-Remember: The margins in responsive are being taken care with container queries in `layout.scss`. So everything related to that, goes like it works in there, with container queries. See implementations for details in case you need it.
+**Remember**: The margins in responsive are being taken care with container queries in `layout.scss`. So everything related to that, goes like it works in there, with container queries. See implementations for details in case you need it.
 
 ## Specification
 
@@ -214,6 +218,15 @@ We have totally different header for intranet sites. If you want that, you can e
 ```js
 config.settings.intranetHeader = true;
 ```
+## Releases
+
+The releases follow a semantic versioning model.
+
+### Definition of breaking change
+
+In general, the same rules as Volto releases applies.
+However, in VLT we add an extra exception: The vertical spacing is carefully curated and considered an important feature of the theme and because of that, changes and improvements in the vertical spacing are **NOT** considered breaking changes.
+They will be noted properly in the changelog.
 
 ## Upgrade Guide
 

--- a/news/353.bugfix
+++ b/news/353.bugfix
@@ -1,1 +1,0 @@
-Remove border and reduce spacing between title and description in teaser block @iFlameing

--- a/news/353.bugfix
+++ b/news/353.bugfix
@@ -1,0 +1,1 @@
+Remove border and reduce spacing between title and description in teaser block @iFlameing

--- a/news/353.feature
+++ b/news/353.feature
@@ -1,0 +1,1 @@
+[Vertical Spacing] Reduce spacing between title and description in teaser block @iFlameing

--- a/src/theme/blocks/_teaser.scss
+++ b/src/theme/blocks/_teaser.scss
@@ -22,6 +22,7 @@
   .teaser-item.default {
     align-items: start;
     padding-bottom: 40px; // same as vertical spacing in margin-bottom
+    border-bottom: 1px solid $black;
   }
 
   .image-wrapper {

--- a/src/theme/blocks/_teaser.scss
+++ b/src/theme/blocks/_teaser.scss
@@ -22,7 +22,6 @@
   .teaser-item.default {
     align-items: start;
     padding-bottom: 40px; // same as vertical spacing in margin-bottom
-    border-bottom: 1px solid $black;
   }
 
   .image-wrapper {
@@ -100,7 +99,7 @@
     }
     h2 {
       margin-top: 0;
-      margin-bottom: 40px;
+      margin-bottom: 20px;
       @include text-heading-h2();
       @container (max-width: #{$largest-mobile-screen}) {
         @include text-heading-h3();


### PR DESCRIPTION
Fixes #353 

It is not a breaking changes but it might change the look of almost all the websites.


Screenshots.

![Screenshot 2024-03-05 at 5 18 13 PM](https://github.com/kitconcept/volto-light-theme/assets/33936987/4150aa39-8fb7-4145-872e-d65eb04b298c)
