### PR TITLE
Fix margin bottom of Event title

### DIFF
--- a/packages/volto-light-theme/news/357.bugfix
+++ b/packages/volto-light-theme/news/357.bugfix
@@ -1,0 +1,1 @@
+Fix event title margin bottom. @iFlameing

--- a/packages/volto-light-theme/src/theme/_content.scss
+++ b/packages/volto-light-theme/src/theme/_content.scss
@@ -59,7 +59,6 @@
 
   .documentFirstHeading {
     margin-top: 0px;
-    margin-bottom: 0px;
   }
 
   .blocks-group-wrapper {


### PR DESCRIPTION
Screenshots

<img width="1211" alt="Screenshot 2024-04-08 at 7 55 54 PM" src="https://github.com/kitconcept/volto-light-theme/assets/33936987/0cde53d3-aced-416a-9076-523e289e5814">
