### PR TITLE
add default width mixin to create content form

### DIFF
--- a/packages/volto-light-theme/news/388.bugfix
+++ b/packages/volto-light-theme/news/388.bugfix
@@ -1,0 +1,1 @@
+Add default width mixin to content creation Forms @danalvrz

--- a/packages/volto-light-theme/src/theme/_layout.scss
+++ b/packages/volto-light-theme/src/theme/_layout.scss
@@ -413,4 +413,15 @@ body.has-toolbar.has-sidebar .block .ui.basic.button.delete-button {
   }
 }
 
+// Create content page form
+#page-add,
+#page-edit {
+  > .container {
+    > .ui.form {
+      margin-top: $spacing-small;
+      @include default-container-width();
+    }
+  }
+}
+
 @import 'bgcolor-blocks-layout';


### PR DESCRIPTION
fixes #385 
<img width="1800" alt="Screenshot" src="https://github.com/kitconcept/volto-light-theme/assets/89805481/c851423b-61af-4608-b1a7-b85b71bd8a91">
