### PR TITLE
Fix Description block width in Edit/Add

### DIFF
--- a/packages/volto-light-theme/news/394.bugfix
+++ b/packages/volto-light-theme/news/394.bugfix
@@ -1,0 +1,1 @@
+Fix Description block width in Edit and Add mode. @danalvrz

--- a/packages/volto-light-theme/src/theme/_layout.scss
+++ b/packages/volto-light-theme/src/theme/_layout.scss
@@ -292,8 +292,7 @@ External link removal for all the blocks.
     .line,
   .block-editor-codeBlock,
   .block-editor-mermaidBlock,
-  .block-editor-description .documentDescription
-   {
+  .block-editor-description .documentDescription {
     @include narrow-container-width();
     @include adjustMarginsToEditContainer($narrow-container-width);
   }

--- a/packages/volto-light-theme/src/theme/_layout.scss
+++ b/packages/volto-light-theme/src/theme/_layout.scss
@@ -291,7 +291,9 @@ External link removal for all the blocks.
     .block.separator
     .line,
   .block-editor-codeBlock,
-  .block-editor-mermaidBlock {
+  .block-editor-mermaidBlock,
+  .block-editor-description .documentDescription
+   {
     @include narrow-container-width();
     @include adjustMarginsToEditContainer($narrow-container-width);
   }


### PR DESCRIPTION
fixes #392 

<img width="1824" alt="Screenshot" src="https://github.com/kitconcept/volto-light-theme/assets/89805481/6f537ff4-0eca-4d1d-ab7f-8847986328fb">
