### PR TITLE
Constrain footer logo proportions to 200x80 (#461)

### DIFF
--- a/packages/volto-light-theme/news/467.bugfix
+++ b/packages/volto-light-theme/news/467.bugfix
@@ -1,0 +1,1 @@
+Constrain logo proportions to 200x80. @kittauri

--- a/packages/volto-light-theme/src/theme/_footer.scss
+++ b/packages/volto-light-theme/src/theme/_footer.scss
@@ -78,15 +78,15 @@
 
     .logo {
       margin: 5rem 0 1.8rem 0;
-      
+
       a {
         display: block;
 
         img {
           width: 100%;
           max-width: 200px;
-          max-height: 80px;
           height: auto;
+          max-height: 80px;
         }
       }
     }

--- a/packages/volto-light-theme/src/theme/_footer.scss
+++ b/packages/volto-light-theme/src/theme/_footer.scss
@@ -77,16 +77,18 @@
     }
 
     .logo {
+      display: flex;
+      justify-content: center;
       margin: 5rem 0 1.8rem 0;
 
       a {
         display: block;
+        max-width: 200px;
+        max-height: 80px;
 
         img {
-          width: 100%;
-          max-width: 200px;
+          max-width: 100%;
           height: auto;
-          max-height: 80px;
         }
       }
     }

--- a/packages/volto-light-theme/src/theme/_footer.scss
+++ b/packages/volto-light-theme/src/theme/_footer.scss
@@ -78,6 +78,17 @@
 
     .logo {
       margin: 5rem 0 1.8rem 0;
+      
+      a {
+        display: block;
+
+        img {
+          width: 100%;
+          max-width: 200px;
+          max-height: 80px;
+          height: auto;
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/kitconcept/volto-light-theme/issues/466