### PR TITLE
fix addon list in documentation

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -44,8 +44,8 @@ In your project or policy add-on {file}`package.json` you should declare all of 
   "@kitconcept/volto-introduction-block",
   "@kitconcept/volto-highlight-block",
   "@kitconcept/volto-separator-block",
-  "@kitconcept/volto-light-theme",
   "@kitconcept/volto-slider-block",
+  "@kitconcept/volto-light-theme",
   "your_policy_addon_here"
 ],
 ```

--- a/packages/volto-light-theme/news/470.documentation
+++ b/packages/volto-light-theme/news/470.documentation
@@ -1,0 +1,1 @@
+Update the order of the addon list so that the override order is correct. @kittauri


### PR DESCRIPTION
Fixes https://github.com/kitconcept/volto-light-theme/issues/470

<!-- readthedocs-preview volto-light-theme start -->
----
📚 Documentation preview 📚: https://volto-light-theme--471.org.readthedocs.build/

<!-- readthedocs-preview volto-light-theme end -->