### PR TITLE
Be more defensive against imperfect blocks in RenderBlocks

### DIFF
--- a/packages/volto-light-theme/news/475.bugfix
+++ b/packages/volto-light-theme/news/475.bugfix
@@ -1,0 +1,1 @@
+Fix RenderBlocks to handle empty blocks more robustly @teekuningas

--- a/packages/volto-light-theme/src/customizations/volto/components/theme/View/RenderBlocks.jsx
+++ b/packages/volto-light-theme/src/customizations/volto/components/theme/View/RenderBlocks.jsx
@@ -88,7 +88,7 @@ const RenderBlocks = (props) => {
         const themes =
           config.blocks.blocksConfig[
             content[blocksFieldname][group[0]]['@type']
-          ].themes ?? config.blocks.themes;
+          ]?.themes ?? config.blocks.themes;
 
         return (
           <MaybeWrap


### PR DESCRIPTION
With empty gridBlock and the new themes we get this when rendering blocks:
```
Cannot read properties of undefined (reading 'themes')
```
I guess it's because "empty" type has not been taken into account. But as a easy fix, perhaps add a "?" to not crash.