### PR TITLE
Header adjustments

### DIFF
--- a/packages/volto-light-theme/news/477.bugfix
+++ b/packages/volto-light-theme/news/477.bugfix
@@ -1,0 +1,1 @@
+Header adjustments for intranet. @sneridagh

--- a/packages/volto-light-theme/src/components/Header/Header.jsx
+++ b/packages/volto-light-theme/src/components/Header/Header.jsx
@@ -94,9 +94,10 @@ const IntranetHeader = ({ pathname, siteLabel, token, siteAction }) => {
               <IntranetSearchWidget />
             </div>
           </div>
-          <Navigation pathname={pathname} />
+          <div className="complimentary-logo"></div>
           <MobileNavigation pathname={pathname} />
         </div>
+        <Navigation pathname={pathname} />
       </div>
     </>
   );

--- a/packages/volto-light-theme/src/theme/_header.scss
+++ b/packages/volto-light-theme/src/theme/_header.scss
@@ -316,6 +316,10 @@
         .menu-drawer {
           @media only screen and (max-width: $computer-breakpoint) {
             top: 210px;
+
+            .search-button {
+              display: none;
+            }
           }
         }
       }
@@ -325,7 +329,6 @@
         }
       }
       .navigation {
-        // flex-basis: 100%;
         margin: 29px auto 0 auto;
       }
     }

--- a/packages/volto-light-theme/src/theme/_header.scss
+++ b/packages/volto-light-theme/src/theme/_header.scss
@@ -297,12 +297,10 @@
     flex-direction: column;
 
     .logo-nav-wrapper {
-      flex-wrap: wrap;
-      justify-content: flex-start;
-
-      .logo {
-        flex: 0 1 auto;
-      }
+      display: flex;
+      flex-direction: row;
+      align-items: baseline;
+      justify-content: space-between;
 
       @media only screen and (max-width: $narrow-container-width) {
         position: relative;
@@ -322,15 +320,72 @@
         }
       }
       .navigation {
-        flex-basis: 100%;
+        // flex-basis: 100%;
         margin: 29px auto 0 auto;
       }
     }
 
-    .search-wrapper {
-      flex: 0 1 auto;
+    .navigation {
+      display: flex;
+      flex: 3.5 1 0;
       align-self: center;
-      margin-left: 209px;
+      justify-content: center;
+      margin-bottom: 40px;
+
+      @media only screen and (max-width: $largest-mobile-screen) {
+        display: none;
+      }
+
+      .desktop.menu {
+        display: flex;
+        justify-content: flex-end;
+
+        a.item {
+          padding: 0 5px;
+          margin: 0 5px;
+          color: $black;
+          font-size: 18px;
+          font-weight: 600;
+          line-height: 24px;
+          text-align: center;
+        }
+      }
+
+      .mobile-menu {
+        .mobile-menu-nav {
+          > div {
+            display: flex;
+            flex-direction: column;
+          }
+
+          a.item {
+            width: 100%;
+            padding: 2rem 1.2rem 1.5rem 1.2rem;
+            color: $black;
+            font-size: 18px;
+
+            &.active {
+              border-bottom: 4px solid $black;
+            }
+          }
+        }
+      }
+    }
+
+    .complimentary-logo {
+      display: flex;
+      max-width: 200px;
+      flex: 1 1 auto;
+      flex-direction: row-reverse;
+    }
+
+    .search-wrapper {
+      display: flex;
+      max-width: 600px;
+      flex: 3.5 1 0;
+      align-self: center;
+      justify-content: center;
+
       @media only screen and (max-width: $narrow-container-width) {
         width: 100%;
         margin-left: 0%;

--- a/packages/volto-light-theme/src/theme/_header.scss
+++ b/packages/volto-light-theme/src/theme/_header.scss
@@ -294,8 +294,6 @@
 
 .header-wrapper.intranet-header {
   .header {
-    flex-direction: column;
-
     .logo-nav-wrapper {
       display: flex;
       flex-direction: row;
@@ -304,6 +302,8 @@
 
       @media only screen and (max-width: $narrow-container-width) {
         position: relative;
+        flex-wrap: wrap;
+        justify-content: flex-start;
       }
 
       .mobile-nav.mobile.only {
@@ -317,6 +317,11 @@
           @media only screen and (max-width: $computer-breakpoint) {
             top: 210px;
           }
+        }
+      }
+      .logo {
+        @media only screen and (max-width: $largest-mobile-screen) {
+          flex: 0 1 auto;
         }
       }
       .navigation {
@@ -377,6 +382,10 @@
       max-width: 200px;
       flex: 1 1 auto;
       flex-direction: row-reverse;
+
+      @media only screen and (max-width: $largest-mobile-screen) {
+        display: none;
+      }
     }
 
     .search-wrapper {
@@ -389,6 +398,9 @@
       @media only screen and (max-width: $narrow-container-width) {
         width: 100%;
         margin-left: 0%;
+      }
+      @media only screen and (max-width: $largest-mobile-screen) {
+        flex: 0 1 auto;
       }
 
       .search {

--- a/packages/volto-light-theme/src/theme/_layout.scss
+++ b/packages/volto-light-theme/src/theme/_layout.scss
@@ -74,6 +74,9 @@ html[style*='padding-right'] .sidebar-container {
 
 // We expect initially three main containers
 .header-wrapper {
+  // This is the pusher for the header under 1440px so over that is tight to the border
+  padding: 0 1em;
+
   .q.container,
   .a.container {
     @include container-preference-order(12);
@@ -129,7 +132,7 @@ footer {
 
 .header-wrapper .header {
   @include layout-container-width();
-  @include adjustMarginsToContainer($layout-container-width);
+  // @include adjustMarginsToContainer($layout-container-width);
 }
 
 .breadcrumbs .breadcrumb {


### PR DESCRIPTION
https://gitlab.kitconcept.io/kitconcept/brh-intranet/-/issues/36

Now the config is centered.

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/13b2f607-dc48-4b0f-9a30-c297b94fee7b" />

I also created a 200px container for the complementary logo use case (BRH) adjusting the whole logo wrapper to that.

 I also realised that the logo was not aligned with the default container (content) over 1440px, while we fixed it in DLR. I fixed it as well.

<img width="332" alt="image" src="https://github.com/user-attachments/assets/2224a32c-6cfb-496c-8988-aba5c725fe81" />

and

<img width="366" alt="image" src="https://github.com/user-attachments/assets/27dcf5aa-a13b-49a7-93f4-71e41eac331a" />


In mobile view is also fixed.

<img width="431" alt="image" src="https://github.com/user-attachments/assets/045a69c0-72f9-42b1-a590-dbff80263365" />

