### PR TITLE
Change the icon for eventCalendar block from description to calendar …

### DIFF
--- a/frontend/packages/volto-light-theme/news/+iconForEventCalendar.bugfix
+++ b/frontend/packages/volto-light-theme/news/+iconForEventCalendar.bugfix
@@ -1,0 +1,1 @@
+Change the icon for eventCalendar block from description to calendar svg. @iFlameing

--- a/frontend/packages/volto-light-theme/src/config/blocks.tsx
+++ b/frontend/packages/volto-light-theme/src/config/blocks.tsx
@@ -34,6 +34,7 @@ import { searchBlockSchemaEnhancer } from '../components/Blocks/Search/schema';
 import gridSVG from '../icons/block_icn_grid.svg';
 import accordionSVG from '../icons/block_icn_accordion.svg';
 import descriptionSVG from '@plone/volto/icons/description.svg';
+import calendarSVG from '@plone/volto/icons/calendar.svg';
 
 import { tocBlockSchemaEnhancer } from '../components/Blocks/Toc/schema';
 import { mapsBlockSchemaEnhancer } from '../components/Blocks/Maps/schema';
@@ -189,7 +190,7 @@ export default function install(config: ConfigType) {
   config.blocks.blocksConfig.eventCalendar = {
     id: 'eventCalendar',
     title: 'Event Calendar',
-    icon: descriptionSVG,
+    icon: calendarSVG,
     group: 'common',
     view: SearchBlockViewEvent,
     edit: SearchBlockEditEvent,


### PR DESCRIPTION
…svg.


Screenshots

<img width="276" height="209" alt="Screenshot 2025-09-08 at 1 26 33 PM" src="https://github.com/user-attachments/assets/7cfa23e9-e786-43eb-a3f4-fcf83b1aa221" />

another screenshot

<img width="252" height="86" alt="Screenshot 2025-09-08 at 1 26 14 PM" src="https://github.com/user-attachments/assets/726733dd-3c5a-481e-85d5-9e2a5baaa8d0" />
