### PR TITLE
Fix person description text overflow in grid listing and teaser blocks

### DIFF
--- a/frontend/packages/volto-light-theme/news/645.bugfix
+++ b/frontend/packages/volto-light-theme/news/645.bugfix
@@ -1,0 +1,1 @@
+Fix person description text overflow in grid listing and teaser blocks @iRohitSingh

--- a/frontend/packages/volto-light-theme/src/components/Summary/PersonSummary.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Summary/PersonSummary.tsx
@@ -34,13 +34,13 @@ const PersonSummary = (props: DefaultSummaryProps) => {
       {!hide_description && <p className="description">{item.description}</p>}
 
       {item.contact_email && (
-        <div className="summary-extra-info">
+        <div className="summary-extra-info email">
           <Icon
             title={intl.formatMessage(messages.email)}
             name={mailSVG}
             size="24px"
           />
-          <a className="summary-email" href={`mailto:${item.contact_email}`}>{item.contact_email}</a>
+          <a href={`mailto:${item.contact_email}`}>{item.contact_email}</a>
         </div>
       )}
 

--- a/frontend/packages/volto-light-theme/src/components/Summary/PersonSummary.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Summary/PersonSummary.tsx
@@ -40,7 +40,7 @@ const PersonSummary = (props: DefaultSummaryProps) => {
             name={mailSVG}
             size="24px"
           />
-          <a href={`mailto:${item.contact_email}`}>{item.contact_email}</a>
+          <a className="summary-email" href={`mailto:${item.contact_email}`}>{item.contact_email}</a>
         </div>
       )}
 

--- a/frontend/packages/volto-light-theme/src/theme/person.scss
+++ b/frontend/packages/volto-light-theme/src/theme/person.scss
@@ -297,7 +297,7 @@ body.person-squared-images,
     .summary-extra-info {
       min-width: 0;
       gap: 6px;
-      a {
+      .summary-email {
         display: block;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/frontend/packages/volto-light-theme/src/theme/person.scss
+++ b/frontend/packages/volto-light-theme/src/theme/person.scss
@@ -295,13 +295,16 @@ body.person-squared-images,
   .card-summary {
     display: grid;
     .summary-extra-info {
-      min-width: 0;
-      gap: 6px;
-      .summary-email {
-        display: block;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
+      gap: 5px;
+      &.email {
+        min-width: 0;
+
+        a {
+          display: block;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
       }
     }
   }

--- a/frontend/packages/volto-light-theme/src/theme/person.scss
+++ b/frontend/packages/volto-light-theme/src/theme/person.scss
@@ -290,3 +290,25 @@ body.person-squared-images,
     }
   }
 }
+// person with Four columns
+.ui.stackable.stretched.four.column.grid {
+  .card-summary {
+    display: grid;
+    .summary-extra-info {
+      min-width: 0;
+      gap: 6px;
+      a {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    }
+  }
+  .block.listing .listing-item.person-listing .card-summary {
+    .summary-room-phone {
+      flex-direction: column;
+      gap: 0;
+    }
+  }
+}


### PR DESCRIPTION
Grid Listing: 

<img width="1195" height="1164" alt="Screenshot 2025-09-08 at 8 12 23 PM" src="https://github.com/user-attachments/assets/d759a2ef-6566-4046-be29-f5197ea59e1d" />



Grid Teaser: 

<img width="1148" height="1235" alt="Screenshot 2025-09-08 at 8 11 51 PM" src="https://github.com/user-attachments/assets/b56ec1b7-5437-44aa-a855-a67fece18d85" />
