### PR TITLE
Revert prepublish

### DIFF
--- a/frontend/packages/volto-light-theme/.release-it.json
+++ b/frontend/packages/volto-light-theme/.release-it.json
@@ -24,7 +24,7 @@
     "tagAnnotation": "Release ${version}"
   },
   "github": {
-    "release": true,
+    "release": false,
     "releaseName": "${version}",
     "releaseNotes": "cat .changelog.draft"
   }


### PR DESCRIPTION
@ericof turns out that 

```
  "plonePrePublish": {
    "publish": false
  },
```

Do not publish at all. We need to document these things throughly, in this case, in publishing things with `repoplone` and their relationship with Cookieplone setup and `prepublish` script. So I guess in core, under Cookieplone docs. I plan to work in these in the next weeks.

Also, internal docs, that's on me too.