### PR TITLE
Fixed icons and spacing in calendar event range widget

### DIFF
--- a/frontend/packages/volto-light-theme/src/components/Blocks/EventCalendar/Search/components/DateRangePicker.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Blocks/EventCalendar/Search/components/DateRangePicker.tsx
@@ -22,6 +22,8 @@ import cx from 'classnames';
 import Icon from '@plone/volto/components/theme/Icon/Icon';
 import CalendarSVG from '@plone/volto/icons/calendar.svg';
 import ClearSVG from '@plone/volto/icons/clear.svg';
+import LeftArrowSVG from '@plone/volto/icons/left-key.svg';
+import RightArrowSVG from '@plone/volto/icons/right-key.svg';
 
 export interface DateRangePickerProps<T extends DateValue>
   extends RACDateRangePickerProps<T> {
@@ -64,13 +66,17 @@ export function DateRangePicker<T extends DateValue>({
 
       {description && <Text slot="description">{description}</Text>}
       <FieldError>{errorMessage}</FieldError>
-      <Popover>
+      <Popover offset={0}>
         <Dialog>
           <RangeCalendar>
             <header>
-              <Button slot="previous">◀</Button>
+              <Button slot="previous">
+                <Icon name={LeftArrowSVG} />
+              </Button>
               <Heading />
-              <Button slot="next">▶</Button>
+              <Button slot="next">
+                <Icon name={RightArrowSVG} />
+              </Button>
             </header>
             <CalendarGrid>
               {(date) => <CalendarCell date={date} />}

--- a/frontend/packages/volto-light-theme/src/theme/blocks/_eventSearch.scss
+++ b/frontend/packages/volto-light-theme/src/theme/blocks/_eventSearch.scss
@@ -417,12 +417,20 @@ This is css code of popup of calendar */
   border-radius: unset;
 }
 .react-aria-RangeCalendar {
+  font-size: 24px;
+
+  table .react-aria-CalendarCell {
+    width: 2.75rem;
+  }
+
   header {
     display: flex;
+    margin: 10px 0 20px 0;
   }
 
   //ask victor about this. Font family causing unwanted problems in rendering of icon.
   .react-aria-Button {
+    border: none;
     border-radius: unset;
     font-family: unset;
   }
@@ -431,4 +439,18 @@ This is css code of popup of calendar */
     font-size: 1.375rem;
     text-align: center;
   }
+}
+
+// body:has(.react-aria-Popover[data-trigger='DateRangePicker'])
+//   .react-aria-Group {
+//   border-bottom: none;
+// }
+
+.react-aria-Popover[data-trigger='DateRangePicker'] {
+  min-width: var(--trigger-width);
+  border-top: none;
+}
+
+.react-aria-Dialog:has(.react-aria-RangeCalendar) {
+  padding: 10px;
 }


### PR DESCRIPTION
<img width="595" height="515" alt="image" src="https://github.com/user-attachments/assets/a1f0e198-4fea-4841-bd1d-c1a9a44295aa" />
