### PR TITLE
PoC for linked cards with semantic link around the title

### DIFF
--- a/frontend/packages/volto-light-theme/src/components/Summary/DefaultSummary.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Summary/DefaultSummary.tsx
@@ -4,6 +4,7 @@ import { smartTextRenderer } from '../../helpers/smartText';
 
 export type DefaultSummaryProps = {
   item: Partial<ObjectBrowserItem>;
+  LinkToItem?: React.ElementType;
   HeadingTag?: React.ElementType;
   a11yLabelId?: string;
   hide_description?: boolean;
@@ -14,13 +15,21 @@ export type SummaryComponentType = React.ComponentType<DefaultSummaryProps> & {
 };
 
 const DefaultSummary = (props: DefaultSummaryProps) => {
-  const { item, HeadingTag = 'h3', a11yLabelId, hide_description } = props;
+  const {
+    item,
+    LinkToItem = React.Fragment,
+    HeadingTag = 'h3',
+    a11yLabelId,
+    hide_description,
+  } = props;
   return (
     <>
       {item?.head_title && <div className="headline">{item.head_title}</div>}
-      <HeadingTag className="title" id={a11yLabelId}>
-        {item.title ? item.title : item.id}
-      </HeadingTag>
+      <LinkToItem>
+        <HeadingTag className="title" id={a11yLabelId}>
+          {item.title ? item.title : item.id}
+        </HeadingTag>
+      </LinkToItem>
       {!hide_description && (
         <p className="description">{smartTextRenderer(item.description)}</p>
       )}

--- a/frontend/packages/volto-light-theme/src/primitives/Card/Card.test.tsx
+++ b/frontend/packages/volto-light-theme/src/primitives/Card/Card.test.tsx
@@ -43,10 +43,16 @@ vi.mock(
 
 type SummaryProps = {
   a11yLabelId?: string;
+  LinkToItem?: React.ElementType;
 };
 
-const SummaryContent = ({ a11yLabelId }: SummaryProps) => (
-  <h3 id={a11yLabelId}>Card title</h3>
+const SummaryContent = ({
+  a11yLabelId,
+  LinkToItem = React.Fragment,
+}: SummaryProps) => (
+  <LinkToItem>
+    <h3>Card title</h3>
+  </LinkToItem>
 );
 
 const BodyContent = () => <div>Body content</div>;

--- a/frontend/packages/volto-light-theme/src/primitives/Card/Card.tsx
+++ b/frontend/packages/volto-light-theme/src/primitives/Card/Card.tsx
@@ -51,7 +51,6 @@ const Card = (props: CardProps) => {
   const href = !hasItem ? props.href : undefined;
   const { className, openLinkInNewTab } = props;
 
-  const a11yLabelId = React.useId();
   const linkRef = React.useRef<HTMLAnchorElement>(null);
 
   const triggerNavigation = () => {
@@ -76,6 +75,24 @@ const Card = (props: CardProps) => {
     }
   };
 
+  const LinkToItem = React.useCallback(
+    ({ children }) => {
+      return (
+        <ConditionalLink
+          className="card-link"
+          condition={isInteractive}
+          href={href}
+          item={item}
+          openLinkInNewTab={openLinkInNewTab}
+          ref={linkRef}
+        >
+          {children}
+        </ConditionalLink>
+      );
+    },
+    [href, item, isInteractive, openLinkInNewTab],
+  );
+
   return (
     <div
       className={cx('card', className)}
@@ -84,17 +101,10 @@ const Card = (props: CardProps) => {
       role={isInteractive ? 'link' : undefined}
       tabIndex={isInteractive ? 0 : undefined}
     >
-      {/* @ts-expect-error since this has no children, should fail */}
-      <ConditionalLink
-        aria-labelledby={a11yLabelId}
-        condition={isInteractive}
-        href={href}
-        item={item}
-        openLinkInNewTab={openLinkInNewTab}
-        ref={linkRef}
-      />
       <div className="card-inner">
-        {childrenWithProps(props.children, { a11yLabelId })}
+        {childrenWithProps(props.children, {
+          LinkToItem,
+        })}
       </div>
     </div>
   );
@@ -144,14 +154,21 @@ const CardImage = (props: CardImageProps) => {
 type CardSummaryProps = {
   /** The ID of the element that labels the card. */
   a11yLabelId?: string;
+  LinkToItem?: React.ElementType;
   children?: React.ReactNode;
 };
 
-const CardSummary = (props: CardSummaryProps) => (
-  <div className="card-summary">
-    {childrenWithProps(props.children, { a11yLabelId: props.a11yLabelId })}
-  </div>
-);
+const CardSummary = (props: CardSummaryProps) => {
+  const { a11yLabelId, LinkToItem } = props;
+  return (
+    <div className="card-summary">
+      {childrenWithProps(props.children, {
+        a11yLabelId,
+        LinkToItem,
+      })}
+    </div>
+  );
+};
 
 const CardActions = (props: any) => (
   <div className="actions-wrapper">{props.children}</div>

--- a/frontend/packages/volto-light-theme/src/theme/card.scss
+++ b/frontend/packages/volto-light-theme/src/theme/card.scss
@@ -3,14 +3,9 @@
   transition: box-shadow 0.15s ease;
 }
 
-.card:has(> a):hover,
-.card:has(> a):focus-within {
+.card:has(a.card-link):hover,
+.card:has(a.card-link):focus-within {
   cursor: pointer;
-}
-
-.card a {
-  inset: 0; /* top:0 right:0 bottom:0 left:0 */
-  text-decoration: none; /* remove default underline */
 }
 
 .card .card-summary,


### PR DESCRIPTION
A client pointed out that the current card implementation doesn't show the href target in the browser status bar.

Here's a proof of concept trying to solve that by moving the card `a` tag to be a normal semantic link around the card title, instead of an empty link at the start of the card.

If this is promising, we need to check carefully that we aren't regressing anything in terms of accessibility, add support for it in the other summary components, and update docs and storybook.

Unfortunately it's breaking because if someone used a custom summary component, it has to be updated or else the card won't be linked.