### PR TITLE
Use breadcrumbs foreground color for links in breadcrumbs by default

### DIFF
--- a/frontend/packages/volto-light-theme/news/+useBreadcrumbsForegroundForLinks.bugfix
+++ b/frontend/packages/volto-light-theme/news/+useBreadcrumbsForegroundForLinks.bugfix
@@ -1,0 +1,1 @@
+Use the CSS prop --breadcrumbs-foregound for breadcrumbs links as default, with --link-foreground-color as fallback. @danalvrz

--- a/frontend/packages/volto-light-theme/src/theme/_bgcolor-blocks-layout.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_bgcolor-blocks-layout.scss
@@ -1426,12 +1426,12 @@
     }
 
     a.section {
-      color: var(--link-foreground-color, --breadcrumbs-foreground);
+      color: var(--breadcrumbs-foreground, --link-foreground-color);
     }
 
     a.home {
       svg {
-        fill: var(--link-foreground-color, --breadcrumbs-foreground) !important;
+        fill: var(--breadcrumbs-foreground, --link-foreground-color) !important;
       }
     }
   }


### PR DESCRIPTION
<img width="1394" height="522" alt="Screenshot 2026-01-15 at 10 07 52 a m" src="https://github.com/user-attachments/assets/0e579c54-8e9b-47ec-a84a-cda375a309af" />
