### PR TITLE
Move the head title after the date in NewsView and EventView, making …

### DIFF
--- a/frontend/packages/volto-light-theme/news/+reorderheadtitle.bugfix
+++ b/frontend/packages/volto-light-theme/news/+reorderheadtitle.bugfix
@@ -1,0 +1,1 @@
+Move the head title after the date in NewsView and EventView, making it consistent with the listing view. @iFlameing

--- a/frontend/packages/volto-light-theme/src/components/Theme/EventView.jsx
+++ b/frontend/packages/volto-light-theme/src/components/Theme/EventView.jsx
@@ -73,14 +73,14 @@ const EventView = (props) => {
   return (
     <Container id="page-document" className="view-wrapper event-view">
       <div className="dates">
-        {content?.head_title && (
-          <span className="head-title"> {content?.head_title}</span>
-        )}{' '}
         {formattedDate ? (
           <span className="day" suppressHydrationWarning>
             {formattedDate}
           </span>
-        ) : null}
+        ) : null}{' '}
+        {content?.head_title && (
+          <span className="head-title"> {content?.head_title}</span>
+        )}
       </div>
       {hasBlocksData(content) ? (
         <>

--- a/frontend/packages/volto-light-theme/src/components/Theme/NewsItemView.jsx
+++ b/frontend/packages/volto-light-theme/src/components/Theme/NewsItemView.jsx
@@ -21,9 +21,6 @@ const NewsItemView = ({ content }) => {
   return (
     <Container id="page-document" className="view-wrapper newsitem-view">
       <div className="dates">
-        {content?.head_title && (
-          <span className="head-title"> {content?.head_title}</span>
-        )}{' '}
         {content.effective ? (
           <FormattedDate
             key="day"
@@ -35,7 +32,10 @@ const NewsItemView = ({ content }) => {
             }}
             className="day"
           />
-        ) : null}
+        ) : null}{' '}
+        {content?.head_title && (
+          <span className="head-title"> {content?.head_title}</span>
+        )}
       </div>
       <RenderBlocks content={content} />
     </Container>

--- a/frontend/packages/volto-light-theme/src/theme/_content.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_content.scss
@@ -1,3 +1,12 @@
+@mixin day-with-head-title-separator {
+  .day:has(+ .head-title) {
+    &::after {
+      margin-left: 8px;
+      content: '|';
+    }
+  }
+}
+
 .ui.basic.segment.content-area {
   // We cancel the padding and margin from the segment
   // allowing the content elements to be the ones that push for
@@ -18,6 +27,8 @@
   #page-document .dates {
     @include default-container-width();
     @include adjustMarginsToContainer($default-container-width);
+    @include day-with-head-title-separator();
+
     margin-top: $spacing-medium;
     margin-bottom: $spacing-medium;
     color: var(--primary-foreground-color);
@@ -25,13 +36,6 @@
       @include body-text-bold();
       letter-spacing: 1px;
       text-transform: uppercase;
-    }
-
-    .head-title:has(+ .day) {
-      &::after {
-        margin-left: 8px;
-        content: '|';
-      }
     }
 
     @container (max-width: #{$tablet-breakpoint} ) {
@@ -91,6 +95,7 @@
     }
   }
   .dates {
+    @include day-with-head-title-separator();
     margin-top: $spacing-medium;
     margin-bottom: $spacing-medium;
     color: var(--primary-foreground-color);
@@ -102,12 +107,6 @@
       @include body-text-bold();
       letter-spacing: 1px;
       text-transform: uppercase;
-    }
-    .head-title {
-      &::after {
-        margin-left: 8px;
-        content: '|';
-      }
     }
     @container (max-width: #{$tablet-breakpoint} ) {
       .day,


### PR DESCRIPTION
…it consistent with the listing view.

screenshots

<img width="1921" height="757" alt="3" src="https://github.com/user-attachments/assets/78b66210-8baa-4422-9b60-9828a0e38102" />


<img width="1916" height="973" alt="2" src="https://github.com/user-attachments/assets/47ee3365-7d0d-4b0b-bcd8-5032d9671280" />



<img width="1907" height="856" alt="1" src="https://github.com/user-attachments/assets/a8d631be-4bb9-45d1-9726-aa972534c4cb" />
