### PR TITLE
fixed the image size being narrow-container-width in edit mode

### DIFF
--- a/frontend/packages/volto-light-theme/news/+imageWidthGrid.bugfix
+++ b/frontend/packages/volto-light-theme/news/+imageWidthGrid.bugfix
@@ -1,0 +1,1 @@
+Fix image size grid-block in editmode. @TimoBroeskamp

--- a/frontend/packages/volto-light-theme/src/theme/blocks/_grid.scss
+++ b/frontend/packages/volto-light-theme/src/theme/blocks/_grid.scss
@@ -184,6 +184,9 @@
   .block-editor-image {
     padding: 0;
     margin: 0.5rem !important;
+    figure {
+      max-width: unset;
+    }
   }
 
   .block.listing {


### PR DESCRIPTION
Fixed the size of a single image in a grid block.