### PR TITLE
Fix mobile sticky menu not showing from 768 to 620px.

### DIFF
--- a/frontend/packages/volto-light-theme/news/+wrongvariable.bugfix
+++ b/frontend/packages/volto-light-theme/news/+wrongvariable.bugfix
@@ -1,0 +1,1 @@
+Fix mobile sticky menu not showing from 768 to 620px. @iFlameing

--- a/frontend/packages/volto-light-theme/src/theme/_mobile-sticky-menu.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_mobile-sticky-menu.scss
@@ -8,7 +8,7 @@
   height: 100px;
   flex-direction: column;
   background-color: var(--sticky-menu-color, #555);
-  @media only screen and (max-width: $narrow-container-width) {
+  @media only screen and (max-width: $largest-mobile-screen) {
     display: block;
   }
 


### PR DESCRIPTION
I used the wrong variable. Instead of the large mobile screen width, I used the narrow container width.