### PR TITLE
single image in gridblock backport fix

### DIFF
--- a/frontend/packages/volto-light-theme/news/+imageWidthGrid.bugfix
+++ b/frontend/packages/volto-light-theme/news/+imageWidthGrid.bugfix
@@ -1,0 +1,1 @@
+Fix image size grid-block in editmode. @TimoBroeskamp

--- a/frontend/packages/volto-light-theme/src/theme/blocks/_grid.scss
+++ b/frontend/packages/volto-light-theme/src/theme/blocks/_grid.scss
@@ -178,6 +178,9 @@
   .block-editor-image {
     padding: 0;
     margin: 0.5rem !important;
+    figure {
+      max-width: unset;
+    }
   }
 
   .block.listing {


### PR DESCRIPTION
Just the backport bugfix of the single image size bug in the grid block.