### PR TITLE
fixed the colophon font-size without a link

### DIFF
--- a/frontend/packages/volto-light-theme/news/+colophonFontSizeFix.bugfix
+++ b/frontend/packages/volto-light-theme/news/+colophonFontSizeFix.bugfix
@@ -1,0 +1,1 @@
+Fixed the colophon font-size for text without a link. @TimoBroeskamp

--- a/frontend/packages/volto-light-theme/src/theme/_footer.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_footer.scss
@@ -320,14 +320,21 @@
     @include add(size, xs);
     @include add(height, s);
 
-    p {
-      @include add(size, xs);
-      @include add(height, s);
+    .slate.widget {
+      width: fit-content;
+      margin-left: auto;
+      margin-right: auto;
+      ul,
+      ol,
+      li,
+      p,
+      a {
+        @include add(size, xs);
+        @include add(height, s);
+      }
     }
 
     a {
-      @include add(size, xs);
-      @include add(height, s);
       color: var(--footer-foreground);
       text-decoration: underline;
     }

--- a/frontend/packages/volto-light-theme/src/theme/_footer.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_footer.scss
@@ -320,6 +320,11 @@
     @include add(size, xs);
     @include add(height, s);
 
+    p {
+      @include add(size, xs);
+      @include add(height, s);
+    }
+
     a {
       @include add(size, xs);
       @include add(height, s);

--- a/frontend/packages/volto-light-theme/src/theme/_footer.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_footer.scss
@@ -322,8 +322,8 @@
 
     .slate.widget {
       width: fit-content;
-      margin-left: auto;
       margin-right: auto;
+      margin-left: auto;
       ul,
       ol,
       li,


### PR DESCRIPTION
I fixed the colophon font-size without a link to also have the right font-size.
https://gitlab.kitconcept.io/kitconcept/distribution-kitconcept-website/-/issues/20