### PR TITLE
fixed links in the controlpanel having underlines

### DIFF
--- a/frontend/packages/volto-light-theme/news/+fixUnderlinedItemsInControlpanel.bugfix
+++ b/frontend/packages/volto-light-theme/news/+fixUnderlinedItemsInControlpanel.bugfix
@@ -1,0 +1,1 @@
+Fixed underlined items in the controlpanel and the contents tab. @TimoBroeskamp

--- a/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
@@ -31,11 +31,13 @@ header .navigation .item {
   font-family: $page-font;
 }
 
-.content-area,
-.breadcrumbs {
-  a:not(.card-primary-link, .label) {
-    color: var(--link-foreground-color, var(--theme-foreground-color));
-    text-decoration: underline;
+.public-ui {
+  .content-area,
+  .breadcrumbs {
+    a:not(.card-primary-link, .label) {
+      color: var(--link-foreground-color, var(--theme-foreground-color));
+      text-decoration: underline;
+    }
   }
 }
 

--- a/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
@@ -31,8 +31,6 @@ header .navigation .item {
   font-family: $page-font;
 }
 
-// testing .item right now
-
 .public-ui,
 .cms-ui.view-editview {
   .content-area,

--- a/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_typo-custom.scss
@@ -31,10 +31,13 @@ header .navigation .item {
   font-family: $page-font;
 }
 
-.public-ui {
+// testing .item right now
+
+.public-ui,
+.cms-ui.view-editview {
   .content-area,
   .breadcrumbs {
-    a:not(.card-primary-link, .label) {
+    a:not(.card-primary-link, .label, .item) {
       color: var(--link-foreground-color, var(--theme-foreground-color));
       text-decoration: underline;
     }

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -19104,7 +19104,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 1.2.0
-      vitest: 2.1.9(@types/node@24.10.1)(@vitest/ui@2.1.9)(jsdom@22.1.0)(less@3.11.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)
+      vitest: 2.1.9(@types/node@24.10.1)(@vitest/ui@2.1.9)(jsdom@21.1.2)(less@3.11.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)
     optional: true
 
   '@vitest/ui@2.1.9(vitest@3.2.4)':


### PR DESCRIPTION
Fixed an issue where all items in the controlpanel and contents tab where displayed with links.

<img width="2472" height="1350" alt="image" src="https://github.com/user-attachments/assets/990564c5-fa8e-486b-b94b-e9438339d5e1" />


<img width="1915" height="637" alt="image" src="https://github.com/user-attachments/assets/a8f1b894-794a-4d25-bfaf-efa68a4a87a7" />
