### PR TITLE
Fat menu: skip opening for top-level items with no children

### DIFF
--- a/frontend/cypress/tests/main/nav.cy.js
+++ b/frontend/cypress/tests/main/nav.cy.js
@@ -61,5 +61,6 @@ context('Navigation Acceptance Tests', () => {
   it('Open destination page if no subitems', function () {
     cy.wait('@content');
     cy.get('ul.desktop-menu a').contains('Just a page').click();
+    cy.get('.documentFirstHeading').should('have.text', 'Just a page');
   });
 });

--- a/frontend/cypress/tests/main/nav.cy.js
+++ b/frontend/cypress/tests/main/nav.cy.js
@@ -26,6 +26,12 @@ context('Navigation Acceptance Tests', () => {
       contentTitle: 'Level 3',
       path: '/level-1/level-2',
     });
+    cy.createContent({
+      contentType: 'Document',
+      contentId: 'a-page',
+      contentTitle: 'Just a page',
+      path: '/',
+    });
 
     cy.visit('/');
     cy.viewport('macbook-16');
@@ -50,5 +56,10 @@ context('Navigation Acceptance Tests', () => {
     cy.get('ul.desktop-menu button').contains('Level 1').click();
     cy.get('.subsubitem-wrapper').findByText('Level 3').click();
     cy.get('.documentFirstHeading').should('have.text', 'Level 3');
+  });
+
+  it('Open destination page if no subitems', function () {
+    cy.wait('@content');
+    cy.get('ul.desktop-menu a').contains('Just a page').click();
   });
 });

--- a/frontend/packages/volto-light-theme/news/848.feature
+++ b/frontend/packages/volto-light-theme/news/848.feature
@@ -1,0 +1,1 @@
+Fat menu now skips opening for top-level items that have no children — clicking the item navigates directly to its destination instead of opening an empty submenu. @ericof

--- a/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
@@ -159,101 +159,109 @@ const Navigation = ({ pathname }: NavigationProps) => {
     >
       <div className={'computer large screen widescreen only'}>
         <ul className="desktop-menu">
-          {items.map((item, index) => (
-            <li key={item.url}>
-              {hasFatMenu ? (
-                <>
-                  <button
-                    onClick={() => openMenu(index)}
-                    className={cx('item', {
-                      active:
-                        desktopMenuOpen === index ||
-                        (!desktopMenuOpen && pathname === item.url),
-                    })}
-                    aria-label={intl.formatMessage(messages.openFatMenu)}
-                    aria-expanded={desktopMenuOpen === index}
-                  >
-                    {item.title}
-                  </button>
-
-                  <div className="submenu-wrapper">
-                    <div
-                      className={cx('submenu', {
-                        active: desktopMenuOpen === index,
+          {items.map((item, index) => {
+            const hasItems = item.items && item.items.length > 0;
+            return (
+              <li key={item.url}>
+                {hasFatMenu && hasItems ? (
+                  <>
+                    <button
+                      onClick={() => openMenu(index)}
+                      className={cx('item', {
+                        active:
+                          desktopMenuOpen === index ||
+                          (!desktopMenuOpen && pathname === item.url),
                       })}
+                      aria-label={intl.formatMessage(messages.openFatMenu)}
+                      aria-expanded={desktopMenuOpen === index}
                     >
-                      <div className="submenu-inner">
-                        <NavLink
-                          to={item.url === '' ? '/' : item.url}
-                          onClick={() => closeMenu()}
-                          className="submenu-header"
-                        >
-                          <h2>{item.nav_title ?? item.title}</h2>
-                        </NavLink>
-                        <button
-                          className="close"
-                          onClick={closeMenu}
-                          aria-label={intl.formatMessage(messages.closeMenu)}
-                        >
-                          <Icon name={clearSVG} size="48px" />
-                        </button>
-                        <ul>
-                          {item.items &&
-                            item.items.length > 0 &&
-                            item.items.map((subitem) => (
-                              <li className="subitem-wrapper" key={subitem.url}>
-                                <NavLink
-                                  to={subitem.url}
-                                  onClick={() => closeMenu()}
-                                  className={cx({
-                                    current: isActive(subitem.url),
-                                  })}
+                      {item.title}
+                    </button>
+
+                    <div className="submenu-wrapper">
+                      <div
+                        className={cx('submenu', {
+                          active: desktopMenuOpen === index,
+                        })}
+                      >
+                        <div className="submenu-inner">
+                          <NavLink
+                            to={item.url === '' ? '/' : item.url}
+                            onClick={() => closeMenu()}
+                            className="submenu-header"
+                          >
+                            <h2>{item.nav_title ?? item.title}</h2>
+                          </NavLink>
+                          <button
+                            className="close"
+                            onClick={closeMenu}
+                            aria-label={intl.formatMessage(messages.closeMenu)}
+                          >
+                            <Icon name={clearSVG} size="48px" />
+                          </button>
+                          <ul>
+                            {item.items &&
+                              item.items.length > 0 &&
+                              item.items.map((subitem) => (
+                                <li
+                                  className="subitem-wrapper"
+                                  key={subitem.url}
                                 >
-                                  <span className="left-arrow">&#8212;</span>
-                                  <span>
-                                    {subitem.nav_title || subitem.title}
-                                  </span>
-                                </NavLink>
-                                <div className="sub-submenu">
-                                  <ul>
-                                    {subitem.items &&
-                                      subitem.items.length > 0 &&
-                                      subitem.items.map((subsubitem) => (
-                                        <li
-                                          className="subsubitem-wrapper"
-                                          key={subsubitem.url}
-                                        >
-                                          <NavLink
-                                            to={subsubitem.url}
-                                            onClick={() => closeMenu()}
-                                            className={cx({
-                                              current: isActive(subsubitem.url),
-                                            })}
+                                  <NavLink
+                                    to={subitem.url}
+                                    onClick={() => closeMenu()}
+                                    className={cx({
+                                      current: isActive(subitem.url),
+                                    })}
+                                  >
+                                    <span className="left-arrow">&#8212;</span>
+                                    <span>
+                                      {subitem.nav_title || subitem.title}
+                                    </span>
+                                  </NavLink>
+                                  <div className="sub-submenu">
+                                    <ul>
+                                      {subitem.items &&
+                                        subitem.items.length > 0 &&
+                                        subitem.items.map((subsubitem) => (
+                                          <li
+                                            className="subsubitem-wrapper"
+                                            key={subsubitem.url}
                                           >
-                                            <span className="left-arrow">
-                                              &#8212;
-                                            </span>
-                                            <span>
-                                              {subsubitem.nav_title ||
-                                                subsubitem.title}
-                                            </span>
-                                          </NavLink>
-                                        </li>
-                                      ))}
-                                  </ul>
-                                </div>
-                              </li>
-                            ))}
-                        </ul>
+                                            <NavLink
+                                              to={subsubitem.url}
+                                              onClick={() => closeMenu()}
+                                              className={cx({
+                                                current: isActive(
+                                                  subsubitem.url,
+                                                ),
+                                              })}
+                                            >
+                                              <span className="left-arrow">
+                                                &#8212;
+                                              </span>
+                                              <span>
+                                                {subsubitem.nav_title ||
+                                                  subsubitem.title}
+                                              </span>
+                                            </NavLink>
+                                          </li>
+                                        ))}
+                                    </ul>
+                                  </div>
+                                </li>
+                              ))}
+                          </ul>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </>
-              ) : (
-                <NavItem item={item} lang={lang} key={item.url} />
-              )}
-            </li>
-          ))}
+                  </>
+                ) : (
+                  <NavItem item={item} lang={lang} key={item.url} />
+                )}
+              </li>
+            );
+          })}
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
## Summary

Fat menu used to open an empty submenu when a top-level navigation item had no children. With this change, those items render as a direct link (`NavItem`) and clicking them navigates straight to the destination.

## Approach

The check uses the existing nav tree — `item.items?.length > 0` — so no catalog metadata or backend changes are required. Per @davisagli's note on #848: for the fat menu we already have the nav tree items, and what matters is "children in the nav structure, not all children".

## Changes

- `Navigation.tsx`: gate the fat-menu UI behind `hasFatMenu && hasItems`; fall through to `NavItem` otherwise.
- `nav.cy.js`: acceptance test creating a top-level page with no children and clicking it from the desktop menu.
- News fragment.

## Test plan

- [x] `make lint` and `make format` clean
- [x] Unit tests pass (`vitest`, 44/44)
- [ ] Cypress acceptance test passes (`pnpm cypress:run` / CI)
- [x] Manual: with fat menu enabled, top-level item with children opens submenu (existing behavior)
- [x] Manual: with fat menu enabled, top-level item without children navigates directly

Closes #848