### PR TITLE
Load site customization fields on error views

### DIFF
--- a/backend/mx.ini
+++ b/backend/mx.ini
@@ -11,6 +11,8 @@ main-package = -e .[test]
 ;     plone.distribution==3.1.1
 ;     plone.exportimport==1.1.0
 ;     plone.restapi==9.13.2
+version-overrides =
+    pytest-plone==1.0.0a3
 
 ; example section to use packages from git
 ; [example.contenttype]

--- a/backend/news/+errorcontext.bugfix
+++ b/backend/news/+errorcontext.bugfix
@@ -1,0 +1,1 @@
+Include site customization fields in error responses. @davisagli

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "plone.exportimport",
     "plone.restapi[test]",
     "pytest-cov",
-    "pytest-plone>=0.5.0",
+    "pytest-plone>=1.0.0a3",
     "pytest",
 ]
 

--- a/backend/src/kitconcept/voltolighttheme/behaviors/customizations.py
+++ b/backend/src/kitconcept/voltolighttheme/behaviors/customizations.py
@@ -270,7 +270,8 @@ class ISiteFooterCustomizationSettings(model.Schema):
             {
                 "children": [
                     {
-                        "text": "Powered by Plone and Volto Light Theme\nThe Plone® Open Source CMS/WCM is © 2000-2026 by the "
+                        "text": "Powered by Plone and Volto Light Theme\n"
+                        "The Plone® Open Source CMS/WCM is © 2000-2026 by the "
                     },
                     {
                         "children": [{"text": "Plone Foundation"}],

--- a/backend/src/kitconcept/voltolighttheme/behaviors/sticky_menu.py
+++ b/backend/src/kitconcept/voltolighttheme/behaviors/sticky_menu.py
@@ -42,7 +42,8 @@ class IStickyMenuSettings(model.Schema):
         ),
         description=_(
             "help_mobile_sticky_menu_enabled",
-            default="If enabled, a sticky menu will be shown at the bottom of the screen.",
+            default="If enabled, a sticky menu will be shown "
+            "at the bottom of the screen.",
         ),
         required=False,
         default=False,

--- a/backend/src/kitconcept/voltolighttheme/browser/configure.zcml
+++ b/backend/src/kitconcept/voltolighttheme/browser/configure.zcml
@@ -1,0 +1,13 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:i18n="http://namespaces.zope.org/i18n"
+    i18n_domain="kitconcept.voltolighttheme"
+    >
+
+  <adapter
+      factory=".errors.VLTErrorHandling"
+      provides="zope.interface.Interface"
+      name="index.html"
+      />
+
+</configure>

--- a/backend/src/kitconcept/voltolighttheme/browser/errors.py
+++ b/backend/src/kitconcept/voltolighttheme/browser/errors.py
@@ -1,0 +1,41 @@
+from AccessControl import getSecurityManager
+from Acquisition import aq_inner
+from kitconcept.voltolighttheme.interfaces import IBrowserLayer
+from plone.rest.errors import ErrorHandling
+from plone.rest.traverse import RESTWrapper
+from plone.restapi.services.inherit.get import InheritedBehaviorExpander
+from Products.CMFCore.interfaces import IDynamicType
+from zope.component import adapter
+
+
+@adapter(Exception, IBrowserLayer)
+class VLTErrorHandling(ErrorHandling):
+    """Add inherited site customization fields to error responses."""
+
+    def render_exception(self, exception):
+        result = super().render_exception(exception)
+
+        # Find the closest visible context,
+        # and add its data from the `inherit` expander
+        closest_context = self._get_closest_visible_context()
+        if closest_context is not None:
+            expander = InheritedBehaviorExpander(closest_context, self.request)
+            result["@components"] = expander(expand=True)
+
+        return result
+
+    def _get_closest_visible_context(self):
+        sm = getSecurityManager()
+        obj = None
+        for parent in self.request["PARENTS"]:
+            if isinstance(parent, RESTWrapper):
+                obj = parent.context
+            elif IDynamicType.providedBy(parent):
+                obj = parent
+            if obj is not None:
+                break
+        if obj is None:
+            return
+        for context in aq_inner(obj).aq_chain:
+            if sm.checkPermission("View", context):
+                return context

--- a/backend/src/kitconcept/voltolighttheme/configure.zcml
+++ b/backend/src/kitconcept/voltolighttheme/configure.zcml
@@ -15,6 +15,7 @@
   <include file="profiles.zcml" />
 
   <include package=".behaviors" />
+  <include package=".browser" />
 
   <include package="plone.volto.cors" />
 

--- a/backend/tests/api/test_errors.py
+++ b/backend/tests/api/test_errors.py
@@ -1,5 +1,7 @@
 def test_error_response_includes_inherit_fields(anon_request):
-    response = anon_request.get("/non-existing?expand=inherit&expand.inherit.behaviors=voltolighttheme.header")
+    response = anon_request.get(
+        "/non-existing?expand=inherit&expand.inherit.behaviors=voltolighttheme.header"
+    )
     assert response.status_code == 404
     assert "@components" in response.json()
     assert "inherit" in response.json()["@components"]

--- a/backend/tests/api/test_errors.py
+++ b/backend/tests/api/test_errors.py
@@ -1,0 +1,5 @@
+def test_error_response_includes_inherit_fields(anon_request):
+    response = anon_request.get("/non-existing?expand=inherit&expand.inherit.behaviors=voltolighttheme.header")
+    assert response.status_code == 404
+    assert "@components" in response.json()
+    assert "inherit" in response.json()["@components"]

--- a/docs/reference/use-live-data.md
+++ b/docs/reference/use-live-data.md
@@ -9,11 +9,12 @@ myst:
 
 # useLiveData Hook
 
-The `useLiveData` hook is a utility in volto-light-them project that provides a **single source of truth** for field values while creating or editing content.
-It ensures that values are always **up-to-date** in both:
+The `useLiveData` hook is a utility `volto-light-theme` that provides a **single source of truth** for field values while creating or editing content.
+It ensures that values are always **up-to-date**:
 
-- **Add/Edit mode** → reads live values from the Redux form store.
+- **Add/Edit mode** → reads live values from the Redux form state.
 - **View mode** → falls back to the content object or inherited behavior data.
+- **Error views** → falls back to inherited behavior data from errorContext in the Redux store.
 
 This allows components to display field values that update immediately as the user types or updates value.
 
@@ -36,6 +37,7 @@ function useLiveData<T>(
 3. Otherwise → return the live form value if present, else fallback to:
    - Behavior data  if behaviour is defined(`content['@components'].inherit[behavior].data[field]`)
    - Or get the direct field value on the content object.
+   - Or get the field value from `state.errorContext` if there is no content object.
 
 This ensures the value is **reactive** to user input while editing and **correctly reflects stored content** in view mode.
 

--- a/frontend/packages/volto-light-theme/news/+errorcontext.bugfix
+++ b/frontend/packages/volto-light-theme/news/+errorcontext.bugfix
@@ -1,0 +1,1 @@
+Fix loading of inherited site customization fields on error views. @davisagli

--- a/frontend/packages/volto-light-theme/src/helpers/useLiveData.ts
+++ b/frontend/packages/volto-light-theme/src/helpers/useLiveData.ts
@@ -6,21 +6,27 @@ type FormState = {
   content: {
     data: Content;
   };
+  errorContext: Content;
   form: {
     global: Content;
   };
 };
 
 export function useLiveData<T>(
-  content: Content,
+  bbbContent: Content,
   behavior: string | undefined,
   field: string,
 ) {
+  const content = useSelector((state: FormState) => state.content?.data);
+  const errorContext = useSelector((state: FormState) => state.errorContext);
+  const context = content ?? errorContext;
+
   const location = useLocation();
   const addMode = location?.pathname?.endsWith('/add');
+
   const current = behavior
-    ? (content?.['@components']?.inherit?.[behavior]?.data?.[field] as T)
-    : (content[field] as T);
+    ? (context?.['@components']?.inherit?.[behavior]?.data?.[field] as T)
+    : (context[field] as T);
 
   const formData = useSelector<FormState, T>(
     (state) => state.form.global?.[field],

--- a/frontend/packages/volto-light-theme/src/helpers/useLiveData.ts
+++ b/frontend/packages/volto-light-theme/src/helpers/useLiveData.ts
@@ -13,11 +13,10 @@ type FormState = {
 };
 
 export function useLiveData<T>(
-  bbbContent: Content,
+  content: Content,
   behavior: string | undefined,
   field: string,
 ) {
-  const content = useSelector((state: FormState) => state.content?.data);
   const errorContext = useSelector((state: FormState) => state.errorContext);
   const context = content ?? errorContext;
 

--- a/frontend/packages/volto-light-theme/src/index.ts
+++ b/frontend/packages/volto-light-theme/src/index.ts
@@ -14,6 +14,8 @@ import installWidgets from './config/widgets';
 import installSlots from './config/slots';
 import installSummary from './config/summary';
 
+import reducers from './reducers';
+
 import '@plone/components/dist/basic.css';
 
 import type {
@@ -97,6 +99,11 @@ const applyConfig = (config: ConfigType) => {
   });
 
   config.views.contentTypesViews.Event = EventView;
+
+  config.addonReducers = {
+    ...config.addonReducers,
+    ...reducers,
+  };
 
   return config;
 };

--- a/frontend/packages/volto-light-theme/src/reducers/errorContext.ts
+++ b/frontend/packages/volto-light-theme/src/reducers/errorContext.ts
@@ -1,0 +1,14 @@
+import { GET_CONTENT } from '@plone/volto/constants/ActionTypes';
+
+const initialState = {};
+
+export default function errorContext(state = initialState, action: any = {}) {
+  switch (action.type) {
+    case `${GET_CONTENT}_PENDING`:
+      return {};
+    case `${GET_CONTENT}_FAIL`:
+      return action.error.response?.body ?? {};
+    default:
+      return state;
+  }
+}

--- a/frontend/packages/volto-light-theme/src/reducers/index.ts
+++ b/frontend/packages/volto-light-theme/src/reducers/index.ts
@@ -1,0 +1,7 @@
+import errorContext from './errorContext';
+
+const reducers = {
+  errorContext,
+};
+
+export default reducers;


### PR DESCRIPTION
@ericof @sneridagh This is my new solution for getting the site customization fields on error views, without needing to make a separate request (which caused a flash while the wrong content was in the redux store). Thoughts?

# Summary

- In the backend: override the exception view to add `['@components']['inherit']` from the closest visible context
- In the frontend: use a reducer to put the data from the exception view into `errorContext` in the redux store, and change `useLiveData` to fall back to that