### PR TITLE
Fix floated image top margin after H2

### DIFF
--- a/frontend/packages/volto-light-theme/news/+fixImageMarginAfterH2.bugfix
+++ b/frontend/packages/volto-light-theme/news/+fixImageMarginAfterH2.bugfix
@@ -1,0 +1,1 @@
+Fix top margin for floated images when following an H2. @danlavrz

--- a/frontend/packages/volto-light-theme/src/theme/blocks/_image.scss
+++ b/frontend/packages/volto-light-theme/src/theme/blocks/_image.scss
@@ -32,6 +32,11 @@ figure {
   &.has--block-alignment--left,
   &.has--block-alignment--right {
     margin-bottom: 0 !important;
+    
+    &:has(+ h2) {
+      margin-top: $spacing-xlarge;
+    }
+    
     figure {
       margin-top: 0 !important;
       margin-bottom: $spacing-small;

--- a/frontend/packages/volto-light-theme/src/theme/blocks/_image.scss
+++ b/frontend/packages/volto-light-theme/src/theme/blocks/_image.scss
@@ -32,11 +32,11 @@ figure {
   &.has--block-alignment--left,
   &.has--block-alignment--right {
     margin-bottom: 0 !important;
-    
+
     &:has(+ h2) {
       margin-top: $spacing-xlarge;
     }
-    
+
     figure {
       margin-top: 0 !important;
       margin-bottom: $spacing-small;


### PR DESCRIPTION
Before:

<img width="1243" height="692" alt="Screenshot 2026-06-09 at 2 02 42 p m" src="https://github.com/user-attachments/assets/7020db84-7db4-4f44-843c-834030e5335d" />

After:

<img width="1179" height="630" alt="Screenshot 2026-06-09 at 2 02 56 p m" src="https://github.com/user-attachments/assets/31a3bd7c-331c-4dbe-b834-72270fe6a83c" />
