### PR TITLE
refactor closing logic for fatnav to ignore all clicks on scrollbar

### DIFF
--- a/frontend/packages/volto-light-theme/news/834.bugfix
+++ b/frontend/packages/volto-light-theme/news/834.bugfix
@@ -1,0 +1,1 @@
+refactor closing logic for fatnav to ignore all clicks on scrollbar @jackahl

--- a/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
@@ -98,23 +98,10 @@ const Navigation = ({ pathname }: NavigationProps) => {
     shallowEqual,
   );
 
-  const closeMenu = () => {
+  const closeMenu = useCallback(() => {
     setDesktopMenuOpen(null);
     setCurrentOpenIndex(null);
-  };
-
-  // this function doesn't close the navigation when clicking the scrollbar
-  const doesScrollbarContainClick = (event: MouseEvent): boolean => {
-    const clickedVerticalScrollbar =
-      event.clientX >= document.documentElement.clientWidth &&
-      event.clientX <= window.innerWidth;
-
-    const clickedHorizontalScrollbar =
-      event.clientY >= document.documentElement.clientHeight &&
-      event.clientY <= window.innerHeight;
-
-    return clickedVerticalScrollbar || clickedHorizontalScrollbar;
-  };
+  }, [setDesktopMenuOpen, setCurrentOpenIndex]);
 
   const handleClickOutside = useCallback(
     (e: MouseEvent) => {
@@ -167,6 +154,7 @@ const Navigation = ({ pathname }: NavigationProps) => {
     return () => {
       window.removeEventListener('keydown', handleEsc);
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (

--- a/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Navigation/Navigation.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import isEmpty from 'lodash/isEmpty';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import { NavLink } from 'react-router-dom';
@@ -116,22 +116,25 @@ const Navigation = ({ pathname }: NavigationProps) => {
     return clickedVerticalScrollbar || clickedHorizontalScrollbar;
   };
 
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (navigation.current && doesNodeContainClick(navigation.current, event))
+  const handleClickOutside = useCallback(
+    (e: MouseEvent) => {
+      const target = e.target;
+      if (
+        (navigation.current && doesNodeContainClick(navigation.current, e)) ||
+        (target instanceof Element && target.parentElement === null)
+      )
         return;
-      // check if scrollbar is clicked
-      if (doesScrollbarContainClick(event)) return;
-
       closeMenu();
-    };
+    },
+    [closeMenu],
+  );
 
+  useEffect(() => {
     document.addEventListener('mousedown', handleClickOutside, false);
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside, false);
     };
-  }, []);
+  }, [handleClickOutside]);
 
   useEffect(() => {
     if (!hasApiExpander('navigation', getBaseUrl(pathname))) {


### PR DESCRIPTION
alternate fix for #834, as @TimoBroeskamp 's fix for it in #835 had issues when there was not permanent scrollbar.