### PR TITLE
Sanitize Docker buildcache key to tolerate slashes in ref names

### DIFF
--- a/.github/workflows/backend-image-build.yml
+++ b/.github/workflows/backend-image-build.yml
@@ -12,6 +12,9 @@ on:
       image-name-suffix:
         required: true
         type: string
+      cache-key-refname:
+        required: true
+        type: string
       plone-version:
         required: true
         type: string
@@ -68,7 +71,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.cache-key-refname }}
           cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.base-tag }},mode=max
           build-args: |
             PLONE_VERSION=${{ inputs.plone-version }}
@@ -120,7 +123,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}-acceptance:buildcache-${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}-acceptance:buildcache-${{ inputs.cache-key-refname }}
           cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}-acceptance:buildcache-${{ inputs.base-tag }},mode=max
           build-args: |
             PLONE_VERSION=${{ inputs.plone-version }}

--- a/.github/workflows/backend-image-release.yml
+++ b/.github/workflows/backend-image-release.yml
@@ -12,6 +12,9 @@ on:
       image-name-suffix:
         required: true
         type: string
+      cache-key-refname:
+        required: true
+        type: string
       plone-version:
         required: true
         type: string
@@ -73,7 +76,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.base-tag }}
-          cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ github.ref_name }},mode=max
+          cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.cache-key-refname }},mode=max
           build-args: |
             PLONE_VERSION=${{ inputs.plone-version }}
             SEED=$GITHUB_RUN_ID

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -75,6 +75,9 @@ on:
       stack-prefix:
         description: "Deploy: Short name to be used to create Traefik labels"
         value: ${{ inputs.stack-prefix }}
+      cache-key-refname:
+        description: "Cache key based on the ref name"
+        value: ${{ jobs.config.outputs.cache-key-refname }}
 
 jobs:
   config:
@@ -91,7 +94,7 @@ jobs:
       environment: ${{ steps.vars.outputs.ENVIRONMENT }}
       stack-name: ${{ steps.vars.outputs.STACK_NAME }}
       stack-file: ${{ steps.vars.outputs.STACK_FILE }}
-      firefox: ${{ steps.vars.outputs.FIREFOX }}
+      cache-key-refname: ${{ steps.vars.outputs.cache-key-refname }}
 
     steps:
       - name: Checkout
@@ -100,6 +103,10 @@ jobs:
       - name: Compute several vars needed for the CI
         id: vars
         run: |
+          sanitize_cache_key() {
+            local value="${1//\//}"
+            echo "${value// /}"
+          }
           echo "BASE_TAG=sha-$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           echo "PLONE_VERSION=$(cat backend/version.txt)" >> $GITHUB_OUTPUT
           python3 -c 'import json; data = json.load(open("./frontend/mrs.developer.json")); print("VOLTO_VERSION=" + (data["core"].get("tag") or "latest"))' >> $GITHUB_OUTPUT
@@ -109,6 +116,7 @@ jobs:
           echo "ENVIRONMENT=${ENVIRONMENT}" >> $GITHUB_OUTPUT
           echo "STACK_NAME=${ENVIRONMENT//./-}" >> $GITHUB_OUTPUT
           echo "STACK_FILE=${STACK_FILE:-devops/stacks/${{ inputs.hostname }}.yml}" >> $GITHUB_OUTPUT
+          echo "cache-key-refname=$(sanitize_cache_key "${{ github.ref_name }}")" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@v4
         id: filter

--- a/.github/workflows/frontend-image-build.yml
+++ b/.github/workflows/frontend-image-build.yml
@@ -12,6 +12,9 @@ on:
       image-name-suffix:
         required: true
         type: string
+      cache-key-refname:
+        required: true
+        type: string
       node-version:
         required: true
         type: string
@@ -70,7 +73,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: true
-          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ github.ref_name }}
+          cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.cache-key-refname }}
           cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.base-tag }},mode=max
           build-args: |
             VOLTO_VERSION=${{ inputs.volto-version }}

--- a/.github/workflows/frontend-image-release.yml
+++ b/.github/workflows/frontend-image-release.yml
@@ -12,6 +12,9 @@ on:
       image-name-suffix:
         required: true
         type: string
+      cache-key-refname:
+        required: true
+        type: string
       volto-version:
         required: true
         type: string
@@ -71,6 +74,6 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.base-tag }}
-          cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ github.ref_name }},mode=max
+          cache-to: type=registry,ref=${{ inputs.image-name-prefix }}-${{ inputs.image-name-suffix }}:buildcache-${{ inputs.cache-key-refname }},mode=max
           build-args: |
             VOLTO_VERSION=${{ inputs.volto-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: backend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       plone-version: ${{ needs.config.outputs.plone-version }}
 
   frontend-lint:
@@ -112,6 +113,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: frontend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       node-version: ${{ needs.config.outputs.node-version }}
       volto-version: ${{ needs.config.outputs.volto-version }}
     permissions:
@@ -199,6 +201,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: backend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       push: ${{ (github.event_name != 'pull_request') && !contains(needs.*.result, 'failure') }}
       plone-version: ${{ needs.config.outputs.plone-version }}
 
@@ -215,6 +218,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: frontend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       push: ${{ (github.event_name != 'pull_request') && !contains(needs.*.result, 'failure') }}
       volto-version: ${{ needs.config.outputs.volto-version }}
     permissions:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -22,6 +22,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: backend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       plone-version: ${{ needs.config.outputs.plone-version }}
 
   backend-release:
@@ -34,6 +35,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: backend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       push: true
       plone-version: ${{ needs.config.outputs.plone-version }}
 
@@ -46,6 +48,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: frontend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       node-version: ${{ needs.config.outputs.node-version }}
       volto-version: ${{ needs.config.outputs.volto-version }}
     permissions:
@@ -62,6 +65,7 @@ jobs:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
       image-name-suffix: frontend
+      cache-key-refname: ${{ needs.config.outputs.cache-key-refname }}
       push: true
       volto-version: ${{ needs.config.outputs.volto-version }}
     permissions:

--- a/news/887.internal
+++ b/news/887.internal
@@ -1,0 +1,1 @@
+Sanitized the Docker buildcache key derived from `github.ref_name` so refs containing a slash (e.g. `feature/foo`) no longer fail `docker/build-push-action`. @ericof


### PR DESCRIPTION
## Summary

`docker/build-push-action` fails when the registry cache ref contains a slash. Several workflows fed the raw `github.ref_name` into `cache-from`/`cache-to`, so any ref with a `/` (e.g. `feature/foo`, `dependabot/npm/...`) broke the build.

This PR computes a sanitized cache key once and threads it through every image build/release.

## Changes

- **config.yml**: add a `sanitize_cache_key()` bash helper that strips `/` and spaces from `github.ref_name`, exposed as a new `cache-key-refname` reusable-workflow output.
- **main.yml** and **tag.yml**: pass `cache-key-refname` into all image build/release jobs.
- **backend-image-build / frontend-image-build / backend-image-release / frontend-image-release**: declare the new `cache-key-refname` input and use it in `cache-from`/`cache-to` instead of the raw `github.ref_name`.
- Add changelog fragment.

## Notes

- `manual-deploy.yml` feeds `github.ref_name` into an image **tag** (not a cache key) — also slash-fragile, but out of scope here. Worth a separate issue.

Closes #887