### PR TITLE
Let projects choose structural components through the registry

### DIFF
--- a/docs/how-to-guides/swap-structural-components.md
+++ b/docs/how-to-guides/swap-structural-components.md
@@ -1,0 +1,117 @@
+---
+myst:
+  html_meta:
+    "description": "Swap structural components in Volto Light Theme through the registry"
+    "property=og:description": "Swap structural components in Volto Light Theme through the registry"
+    "property=og:title": "Swap structural components"
+    "keywords": "Volto Light Theme, registry, utility, header, navigation, footer, customization"
+---
+
+# Swap structural components
+
+Volto Light Theme (VLT) renders its structural components — the header, navigation, footer, and a few more — through the component registry from `@plone/registry`.
+This lets a project replace any of them with its own implementation by registering a utility and flipping a setting, instead of shadowing the component through {file}`customizations`.
+
+Compared to shadowing, this approach is:
+
+-   **Explicit.** The active component is named in configuration, not hidden in a file under {file}`customizations`.
+-   **Composable.** Several implementations can coexist under different names; a project selects which one renders.
+-   **Decoupled.** A project binds to a stable name, not to an internal module path.
+
+## How it works
+
+VLT registers its own implementation of each structural component as a utility under the name `vlt`, with a `type` that names the role.
+
+```js
+config.registerUtility({ name: 'vlt', type: 'navigation', method: Navigation });
+```
+
+A setting then selects which registered name renders for each role.
+
+```js
+config.settings.vlt = {
+  components: {
+    breadcrumbs: 'vlt',
+    footer: 'vlt',
+    header: 'vlt',
+    languageSelector: 'vlt',
+    logo: 'vlt',
+    mobileNavigation: 'vlt',
+    navigation: 'vlt',
+    searchWidget: 'vlt',
+    tags: 'vlt',
+  },
+};
+```
+
+These defaults reproduce the theme's standard behavior, so enabling nothing changes nothing.
+
+## Available components
+
+The following roles can be swapped. The value is the `type` you register against and the key you set under `config.settings.vlt.components`.
+
+| Setting            | Role                                            |
+| ------------------ | ----------------------------------------------- |
+| `breadcrumbs`      | The breadcrumbs trail                           |
+| `footer`           | The site footer                                 |
+| `header`           | The site header                                 |
+| `languageSelector` | The language selector in the header             |
+| `logo`             | The site logo                                   |
+| `mobileNavigation` | The mobile (hamburger) navigation               |
+| `navigation`       | The main desktop navigation                     |
+| `searchWidget`     | The header search widget                        |
+| `tags`             | The tags shown on content                       |
+
+## Swap the navigation
+
+Suppose your project add-on `@acme/volto` ships its own navigation and you want the site to use it.
+
+### 1. Register your component
+
+In your add-on's configuration, register your navigation under your own name and the `navigation` type.
+
+```js
+import AcmeNavigation from './components/AcmeNavigation';
+
+export default function applyConfig(config) {
+  config.registerUtility({
+    name: 'acme',
+    type: 'navigation',
+    method: AcmeNavigation,
+  });
+
+  return config;
+}
+```
+
+Both implementations now live in the registry: the theme's `vlt` navigation and your `acme` one. Nothing renders differently yet.
+
+### 2. Select it
+
+Flip the one setting for the role you want to replace.
+
+```js
+config.settings.vlt.components.navigation = 'acme';
+```
+
+That is the whole change. The theme's header resolves the navigation through the registry at render time, so it now renders `AcmeNavigation`. Every other role keeps its `vlt` default.
+
+```{note}
+Make sure your add-on loads after `@kitconcept/volto-light-theme` so that `config.settings.vlt` already exists when you assign to it. Placing VLT before your add-on in your project's add-ons list is enough.
+```
+
+## Fallback behavior
+
+If a setting names a component that is not registered, VLT falls back to its own `vlt` implementation rather than failing to render.
+
+```js
+// 'typo' is not registered, so the theme's own navigation renders.
+config.settings.vlt.components.navigation = 'typo';
+```
+
+This makes a misconfiguration degrade to the default instead of producing a blank or broken region.
+
+## Type safety
+
+The component settings are typed through the `VLTSettings` interface, which augments Volto's `SettingsConfig`.
+The keys of `config.settings.vlt.components` are a fixed set, so a typo in a role name is a compile-time error rather than a silent no-op at render.

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,6 +42,7 @@ _Volto Light Theme_
 how-to-guides/install
 how-to-guides/summary
 how-to-guides/remove-colophon
+how-to-guides/swap-structural-components
 how-to-guides/social-media
 how-to-guides/acceptance-tests
 how-to-guides/visual-regression-tests

--- a/frontend/packages/volto-light-theme/news/904.feature
+++ b/frontend/packages/volto-light-theme/news/904.feature
@@ -1,0 +1,1 @@
+Let projects choose the structural components (header, navigation, mobile navigation, footer, breadcrumbs, language selector, logo, search widget, and tags) through the registry, selecting each one via `config.settings.vlt.components` instead of shadowing. @ericof

--- a/frontend/packages/volto-light-theme/src/components/Header/Header.tsx
+++ b/frontend/packages/volto-light-theme/src/components/Header/Header.tsx
@@ -10,16 +10,12 @@ import {
   setMetadataFocus,
 } from '@plone/volto/actions/sidebar/sidebar';
 import { flattenToAppURL } from '@plone/volto/helpers/Url/Url';
-import LanguageSelector from '@plone/volto/components/theme/LanguageSelector/LanguageSelector';
-import Logo from '@plone/volto/components/theme/Logo/Logo';
-import Navigation from '@plone/volto/components/theme/Navigation/Navigation';
-import SearchWidget from '@plone/volto/components/theme/SearchWidget/SearchWidget';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import SlotRenderer from '@plone/volto/components/theme/SlotRenderer/SlotRenderer';
 
 import { useLiveData } from '@kitconcept/volto-light-theme/helpers/useLiveData';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
 
-import MobileNavigation from '../MobileNavigation/MobileNavigation';
 import IntranetSearchWidget from '../SearchWidget/IntranetSearchWidget';
 
 import type { SiteHeaderSettings } from '../../types';
@@ -40,6 +36,11 @@ type FormState = {
 };
 
 const InternetHeader = ({ pathname, content }) => {
+  const Logo = getVLTComponent('logo');
+  const Navigation = getVLTComponent('navigation');
+  const MobileNavigation = getVLTComponent('mobileNavigation');
+  const LanguageSelector = getVLTComponent('languageSelector');
+  const SearchWidget = getVLTComponent('searchWidget');
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
     setIsClient(true);
@@ -124,6 +125,10 @@ const InternetHeader = ({ pathname, content }) => {
 };
 
 const IntranetHeader = ({ pathname, content }) => {
+  const Logo = getVLTComponent('logo');
+  const Navigation = getVLTComponent('navigation');
+  const MobileNavigation = getVLTComponent('mobileNavigation');
+  const LanguageSelector = getVLTComponent('languageSelector');
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
     setIsClient(true);

--- a/frontend/packages/volto-light-theme/src/config/components.ts
+++ b/frontend/packages/volto-light-theme/src/config/components.ts
@@ -1,0 +1,39 @@
+import type { ComponentType } from 'react';
+import type { ConfigType } from '@plone/registry';
+import type { ComponentSlot } from '../helpers/settings';
+
+import Breadcrumbs from '../components/Breadcrumbs/Breadcrumbs';
+import Footer from '../components/Footer/Footer';
+import Header from '../components/Header/Header';
+import LanguageSelector from '../components/LanguageSelector/LanguageSelector';
+import Logo from '../components/Logo/Logo';
+import MobileNavigation from '../components/MobileNavigation/MobileNavigation';
+import Navigation from '../components/Navigation/Navigation';
+import SearchWidget from '../components/SearchWidget/SearchWidget';
+import Tags from '../components/Tags/Tags';
+
+// The theme's own implementation for every swappable structural component,
+// registered under the `vlt` name. Keying by `ComponentSlot` makes TypeScript
+// require an entry here whenever a slot is added to `VLTSettings`.
+const components: Record<ComponentSlot, ComponentType<any>> = {
+  breadcrumbs: Breadcrumbs,
+  footer: Footer,
+  header: Header,
+  languageSelector: LanguageSelector,
+  logo: Logo,
+  mobileNavigation: MobileNavigation,
+  navigation: Navigation,
+  searchWidget: SearchWidget,
+  tags: Tags,
+};
+
+function registerComponents(config: ConfigType) {
+  for (const [type, method] of Object.entries(components)) {
+    config.registerUtility({ name: 'vlt', type, method });
+  }
+}
+
+export default function install(config: ConfigType) {
+  registerComponents(config);
+  return config;
+}

--- a/frontend/packages/volto-light-theme/src/config/settings.ts
+++ b/frontend/packages/volto-light-theme/src/config/settings.ts
@@ -1,10 +1,12 @@
 import type { ConfigType } from '@plone/registry';
+import type { VLTSettings } from '../types';
 
 declare module '@plone/types' {
   export interface SettingsConfig {
     slate: {
       useLinkedHeadings: boolean;
     };
+    vlt?: VLTSettings;
   }
 }
 
@@ -23,6 +25,19 @@ export default function install(config: ConfigType) {
   const EXPANDERS_INHERIT_BEHAVIORS =
     'voltolighttheme.header,voltolighttheme.theme,voltolighttheme.footer,kitconcept.footer,kitconcept.sticky_menu';
   config.settings.enableAutoBlockGroupingByBackgroundColor = true;
+  config.settings.vlt = {
+    components: {
+      breadcrumbs: 'vlt',
+      footer: 'vlt',
+      header: 'vlt',
+      languageSelector: 'vlt',
+      logo: 'vlt',
+      mobileNavigation: 'vlt',
+      navigation: 'vlt',
+      searchWidget: 'vlt',
+      tags: 'vlt',
+    },
+  };
   config.settings.navDepth = 3;
   config.settings.slate.useLinkedHeadings = false;
   config.settings.contentMetadataTagsImageField = 'preview_image';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -1,11 +1,16 @@
 /**
  * OVERRIDE Breadcrumbs.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the breadcrumbs through the component registry so a
+ * project can swap it via `config.settings.vlt.components.breadcrumbs` instead
+ * of shadowing this file. To replace it, register your own utility and flip the
+ * setting.
  */
 
-import Breadcrumbs from '../../../../../components/Breadcrumbs/Breadcrumbs';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Breadcrumbs = (props) => {
+  const BreadcrumbsComponent = getVLTComponent('breadcrumbs');
+  return <BreadcrumbsComponent {...props} />;
+};
 
 export default Breadcrumbs;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -1,11 +1,15 @@
 /**
  * OVERRIDE Footer.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the footer through the component registry so a project
+ * can swap it via `config.settings.vlt.components.footer` instead of shadowing
+ * this file. To replace it, register your own utility and flip the setting.
  */
 
-import Footer from '../../../../../components/Footer/Footer';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Footer = (props) => {
+  const FooterComponent = getVLTComponent('footer');
+  return <FooterComponent {...props} />;
+};
 
 export default Footer;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Header/Header.jsx
@@ -1,11 +1,15 @@
 /**
  * OVERRIDE Header.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the header through the component registry so a project
+ * can swap it via `config.settings.vlt.components.header` instead of shadowing
+ * this file. To replace it, register your own utility and flip the setting.
  */
 
-import Header from '../../../../../components/Header/Header';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Header = (props) => {
+  const HeaderComponent = getVLTComponent('header');
+  return <HeaderComponent {...props} />;
+};
 
 export default Header;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/LanguageSelector/LanguageSelector.tsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/LanguageSelector/LanguageSelector.tsx
@@ -1,10 +1,16 @@
 /**
  * OVERRIDE LanguageSelector.tsx
- * REASON: Show only two letters of the native language name.
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the language selector through the component registry so
+ * a project can swap it via `config.settings.vlt.components.languageSelector`
+ * instead of shadowing this file. To replace it, register your own utility and
+ * flip the setting.
  */
-import LanguageSelector from '../../../../../components/LanguageSelector/LanguageSelector';
+
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const LanguageSelector = (props) => {
+  const LanguageSelectorComponent = getVLTComponent('languageSelector');
+  return <LanguageSelectorComponent {...props} />;
+};
 
 export default LanguageSelector;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -1,11 +1,15 @@
 /**
  * OVERRIDE Logo.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the logo through the component registry so a project can
+ * swap it via `config.settings.vlt.components.logo` instead of shadowing this
+ * file. To replace it, register your own utility and flip the setting.
  */
 
-import Logo from '../../../../../components/Logo/Logo';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Logo = (props) => {
+  const LogoComponent = getVLTComponent('logo');
+  return <LogoComponent {...props} />;
+};
 
 export default Logo;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -1,11 +1,16 @@
 /**
  * OVERRIDE Navigation.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the navigation through the component registry so a
+ * project can swap it via `config.settings.vlt.components.navigation` instead
+ * of shadowing this file. To replace it, register your own utility and flip the
+ * setting.
  */
 
-import Navigation from '../../../../../components/Navigation/Navigation';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Navigation = (props) => {
+  const NavigationComponent = getVLTComponent('navigation');
+  return <NavigationComponent {...props} />;
+};
 
 export default Navigation;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
@@ -1,11 +1,16 @@
 /**
  * OVERRIDE SearchWidget.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the search widget through the component registry so a
+ * project can swap it via `config.settings.vlt.components.searchWidget` instead
+ * of shadowing this file. To replace it, register your own utility and flip the
+ * setting.
  */
 
-import SearchWidget from '../../../../../components/SearchWidget/SearchWidget';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const SearchWidget = (props) => {
+  const SearchWidgetComponent = getVLTComponent('searchWidget');
+  return <SearchWidgetComponent {...props} />;
+};
 
 export default SearchWidget;

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Tags/Tags.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Tags/Tags.jsx
@@ -1,11 +1,15 @@
 /**
  * OVERRIDE Tags.jsx
- * REASON: This theme uses a custom pre-@plone/components component
- * SemanticUI-free located at the components folder.
- * To override it, override the @kitconcept/volto-light-theme one instead of
- * this one.
+ * REASON: VLT resolves the tags through the component registry so a project can
+ * swap it via `config.settings.vlt.components.tags` instead of shadowing this
+ * file. To replace it, register your own utility and flip the setting.
  */
 
-import Tags from '../../../../../components/Tags/Tags';
+import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';
+
+const Tags = (props) => {
+  const TagsComponent = getVLTComponent('tags');
+  return <TagsComponent {...props} />;
+};
 
 export default Tags;

--- a/frontend/packages/volto-light-theme/src/helpers/settings.test.ts
+++ b/frontend/packages/volto-light-theme/src/helpers/settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import config from '@plone/volto/registry';
+import { getVLTComponent } from './settings';
+
+const VltNavigation = () => null;
+const AcmeNavigation = () => null;
+const VltFooter = () => null;
+
+describe('helpers/settings', () => {
+  beforeEach(() => {
+    config._data.utilities = {};
+    config.registerUtility({
+      name: 'vlt',
+      type: 'navigation',
+      method: VltNavigation,
+    });
+    config.registerUtility({
+      name: 'acme',
+      type: 'navigation',
+      method: AcmeNavigation,
+    });
+    config.registerUtility({ name: 'vlt', type: 'footer', method: VltFooter });
+    config.settings.vlt = {
+      components: {
+        header: 'vlt',
+        navigation: 'acme',
+        mobileNavigation: 'vlt',
+        footer: 'vlt',
+      },
+    };
+  });
+
+  describe('getVLTComponent', () => {
+    it('returns the component the settings select', () => {
+      expect(getVLTComponent('navigation')).toBe(AcmeNavigation);
+    });
+
+    it('falls back to vlt when the configured name is not registered', () => {
+      config.settings.vlt!.components.navigation = 'nope';
+      expect(getVLTComponent('navigation')).toBe(VltNavigation);
+    });
+
+    it('falls back to vlt when no settings are present', () => {
+      config.settings.vlt = undefined;
+      expect(getVLTComponent('navigation')).toBe(VltNavigation);
+    });
+  });
+});

--- a/frontend/packages/volto-light-theme/src/helpers/settings.ts
+++ b/frontend/packages/volto-light-theme/src/helpers/settings.ts
@@ -1,0 +1,16 @@
+import React from 'react';
+import config from '@plone/volto/registry';
+import type { VLTSettings } from '../types';
+
+const defaultComponent = 'vlt';
+
+export type ComponentSlot = keyof VLTSettings['components'];
+
+export function getVLTComponent(type: ComponentSlot): React.ComponentType<any> {
+  const settings = config.settings.vlt?.components;
+  const name = settings?.[type] || defaultComponent;
+  const component = config.getUtility({ name, type }).method;
+  return (
+    component || config.getUtility({ name: defaultComponent, type }).method
+  );
+}

--- a/frontend/packages/volto-light-theme/src/index.ts
+++ b/frontend/packages/volto-light-theme/src/index.ts
@@ -9,6 +9,7 @@ import { migrateToVLT6ColorAndWidthModel } from './transforms/to6';
 import { migrateToVLT8FloatingBlocks } from './transforms/to8';
 
 import installSettings from './config/settings';
+import installComponents from './config/components';
 import installBlocks from './config/blocks';
 import installClassExtenders from './config/classExtenders';
 import installWidgets from './config/widgets';
@@ -80,6 +81,7 @@ declare module '@plone/types' {
 
 const applyConfig = (config: ConfigType) => {
   installSettings(config);
+  installComponents(config);
   installBlocks(config);
   installClassExtenders(config);
   installWidgets(config);

--- a/frontend/packages/volto-light-theme/src/types.d.ts
+++ b/frontend/packages/volto-light-theme/src/types.d.ts
@@ -96,6 +96,20 @@ export type CustomInheritBehavior<T> = {
   };
 };
 
+export type VLTSettings = {
+  components: {
+    breadcrumbs: string;
+    footer: string;
+    header: string;
+    languageSelector: string;
+    logo: string;
+    mobileNavigation: string;
+    navigation: string;
+    searchWidget: string;
+    tags: string;
+  };
+};
+
 declare module '@plone/types' {
   export interface Content {
     footer_logos: Array<footerLogo>;

--- a/news/904.documentation
+++ b/news/904.documentation
@@ -1,0 +1,1 @@
+Added a how-to guide explaining how to swap structural components through the registry. @ericof


### PR DESCRIPTION
## Summary

Structural components — the header, navigation, footer, and several more — could previously only be replaced by shadowing them through `customizations/`. That is global, invisible in configuration, and coupled to internal module paths.

This PR registers each structural component as a `@plone/registry` utility under the name `vlt`, and resolves it through `config.settings.vlt.components` at render time. A project can register its own implementation and select it with a single setting, no shadowing required, with both implementations staying available.

Closes #904

## Swappable components

Nine roles can be selected via `config.settings.vlt.components`:

`breadcrumbs`, `footer`, `header`, `languageSelector`, `logo`, `mobileNavigation`, `navigation`, `searchWidget`, `tags`.

## How a project uses it

```js
// Register your own under your own name.
config.registerUtility({ name: 'acme', type: 'navigation', method: AcmeNavigation });

// Select it.
config.settings.vlt.components.navigation = 'acme';
```

## What changed

- **`config/components.ts`** — registers every structural component as a `vlt` utility. The registration map is keyed by `ComponentSlot`, so TypeScript requires an entry whenever a slot is added to the settings type.
- **`helpers/settings.ts`** — `getVLTComponent(type)` resolver with a safe fallback to the theme's own component when a configured name is not registered.
- **Header/Footer and the individual component customizations** — now resolve through `getVLTComponent` instead of re-exporting a fixed component. This indirection is the seam the setting acts on.
- **`config/settings.ts` / `types.d.ts`** — typed `VLTSettings` augmenting `SettingsConfig`, with defaults that reproduce today's behavior exactly.

## Backwards compatibility

Defaults select `vlt` for every role, so an existing site renders identically. An unregistered name falls back to the theme's own component rather than failing to render.

## Testing

- New unit tests cover the resolver: correct selection, fallback on an unregistered name, and the no-settings case.
- Full frontend unit suite passes (88/88).

## Documentation

New how-to guide: **Swap structural components**, with a worked "swap the navigation" example.

<!-- readthedocs-preview volto-light-theme start -->
----
📚 Documentation preview 📚: https://volto-light-theme--905.org.readthedocs.build/

<!-- readthedocs-preview volto-light-theme end -->