### PR TITLE
Bump outdated GitHub Actions major versions

### DIFF
--- a/.github/workflows/backend-coverage.yml
+++ b/.github/workflows/backend-coverage.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Install the latest version of uv
           uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/backend-image-build.yml
+++ b/.github/workflows/backend-image-build.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -86,7 +86,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/backend-image-release.yml
+++ b/.github/workflows/backend-image-release.yml
@@ -32,7 +32,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/backend-lint.yml
+++ b/.github/workflows/backend-lint.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Install the latest version of uv
           uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/backend-test.yml
+++ b/.github/workflows/backend-test.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
         - name: Checkout
-          uses: actions/checkout@v6
+          uses: actions/checkout@v7
 
         - name: Install the latest version of uv
           uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
       repository: ${{ steps.filter.outputs.repository }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - uses: dorny/paths-filter@v4
         id: filter
@@ -41,7 +41,7 @@ jobs:
     needs:
       - config
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch all history
           fetch-depth: '0'
@@ -67,7 +67,7 @@ jobs:
       run:
         working-directory: ./frontend
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch all history
           fetch-depth: '0'
@@ -76,7 +76,7 @@ jobs:
         run: pip install towncrier
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -88,7 +88,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -115,7 +115,7 @@ jobs:
     needs:
       - config
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Fetch all history
           fetch-depth: '0'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Compute several vars needed for the CI
         id: vars

--- a/.github/workflows/cypress-no-only.yml
+++ b/.github/workflows/cypress-no-only.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Fail if Cypress tests contain .only"
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v8.1.0

--- a/.github/workflows/frontend-acceptance.yml
+++ b/.github/workflows/frontend-acceptance.yml
@@ -35,7 +35,7 @@ jobs:
     name: ${{ inputs.name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set artifact name
         run: |
@@ -50,7 +50,7 @@ jobs:
           docker image ls -a
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -62,7 +62,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -72,7 +72,7 @@ jobs:
 
       - name: Cache Cypress Binary
         id: cache-cypress-binary
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cache/Cypress
           key: binary-${{ env.NODE_VERSION }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -85,7 +85,7 @@ jobs:
         working-directory: ./frontend/core/packages/volto
         run: make cypress-install
 
-      - uses: JarvusInnovations/background-action@v1.0.7
+      - uses: JarvusInnovations/background-action@v2
         name: Start Servers
         if: ${{ inputs.a11y == false || inputs.a11y == 'false' || inputs.a11y == null }}
         with:
@@ -120,7 +120,7 @@ jobs:
 
           # working-directory: backend
 
-      - uses: JarvusInnovations/background-action@v1.0.7
+      - uses: JarvusInnovations/background-action@v2
         name: Start Servers
         if: ${{inputs.a11y == true || inputs.a11y == 'true' }}
         with:

--- a/.github/workflows/frontend-i18n.yml
+++ b/.github/workflows/frontend-i18n.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Main checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/frontend-image-build.yml
+++ b/.github/workflows/frontend-image-build.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Docker meta
         id: meta

--- a/.github/workflows/frontend-image-release.yml
+++ b/.github/workflows/frontend-image-release.yml
@@ -30,7 +30,7 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Main checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/frontend-storybook.yml
+++ b/.github/workflows/frontend-storybook.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Node.js environment
         uses: ./.github/actions/node_setup

--- a/.github/workflows/frontend-unit.yml
+++ b/.github/workflows/frontend-unit.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Main checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}

--- a/.github/workflows/frontend-visual-regression.yml
+++ b/.github/workflows/frontend-visual-regression.yml
@@ -36,10 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Checkout visual regression assets
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: kitconcept/vlt-visual-regression
           ref: main
@@ -60,7 +60,7 @@ jobs:
           path: frontend/storybook-build
 
       - name: Use Node.js ${{ inputs.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ inputs.node-version }}
 
@@ -72,7 +72,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -89,7 +89,7 @@ jobs:
 
       # STORYBOOK TESTS
       - name: Start Servers - Storybook
-        uses: JarvusInnovations/background-action@v1.0.7
+        uses: JarvusInnovations/background-action@v2
         if: ${{ inputs.storybook == true || inputs.storybook == 'true' }}
         with:
           run: |
@@ -107,7 +107,7 @@ jobs:
         run: pnpm exec playwright test playwright/tests/visual/storybook/${{ inputs.short-name }}.test.{js,jsx,ts,tsx}
 
       # Volto TESTS
-      - uses: JarvusInnovations/background-action@v1.0.7
+      - uses: JarvusInnovations/background-action@v2
         if: ${{ inputs.storybook == false || inputs.storybook == 'false' || inputs.storybook == null }}
         name: Start Servers - Volto and Plone
         with:

--- a/.github/workflows/update-visual-regression-screenshots-storybook.yml
+++ b/.github/workflows/update-visual-regression-screenshots-storybook.yml
@@ -44,10 +44,10 @@ jobs:
       contents: write # needs to push changes
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Checkout visual regression assets
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: kitconcept/vlt-visual-regression
           ref: main
@@ -61,7 +61,7 @@ jobs:
           git config --global user.email "${{ env.AUTHOR_EMAIL }}"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -87,7 +87,7 @@ jobs:
           path: frontend/storybook-build
 
       - name: Start Servers - Storybook
-        uses: JarvusInnovations/background-action@v1.0.7
+        uses: JarvusInnovations/background-action@v2
         with:
           run: |
             python3 -m http.server 6006 -d frontend/storybook-build &

--- a/.github/workflows/update-visual-regression-screenshots.yml
+++ b/.github/workflows/update-visual-regression-screenshots.yml
@@ -44,7 +44,7 @@ jobs:
       contents: write # needs to push changes
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Load images
         run: |
@@ -52,7 +52,7 @@ jobs:
           docker pull ${{ needs.config.outputs.image-name-prefix }}-frontend:${{ needs.config.outputs.base-tag }}
 
       - name: Checkout visual regression assets
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: kitconcept/vlt-visual-regression
           ref: main
@@ -66,7 +66,7 @@ jobs:
           git config --global user.email "${{ env.AUTHOR_EMAIL }}"
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -78,7 +78,7 @@ jobs:
         run: |
           echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@v6
         name: Setup pnpm cache
         with:
           path: ${{ env.STORE_PATH }}
@@ -93,7 +93,7 @@ jobs:
         working-directory: frontend/packages/volto-light-theme
         run: pnpm exec playwright install --with-deps chromium
 
-      - uses: JarvusInnovations/background-action@v1.0.7
+      - uses: JarvusInnovations/background-action@v2
         name: Start Servers - Volto and Plone
         with:
           run: |

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,3 +23,4 @@ You can find the documentation of this package at https://volto-light-theme.read
 ## Upgrade Guide
 
 See a detailed upgrade guide at https://volto-light-theme.readthedocs.io/latest/upgrade-guide.html.
+

--- a/news/915.internal
+++ b/news/915.internal
@@ -1,0 +1,1 @@
+Bump outdated GitHub Actions to their latest major versions: `actions/checkout` v6 -> v7, `actions/setup-node` v6 -> v7, `actions/cache` v5 -> v6, and `JarvusInnovations/background-action` v1 -> v2. @sneridagh


### PR DESCRIPTION
Bumps outdated GitHub Actions pins to their latest major versions.

## Changes

| Action | From → To | Occurrences |
|--------|-----------|-------------|
| \`actions/checkout\` | v6 → v7 | 26 |
| \`actions/setup-node\` | v6 → v7 | 8 |
| \`actions/cache\` | v5 → v6 | 9 |
| \`JarvusInnovations/background-action\` | v1.0.7 → v2 | 6 |

## Notes

- **Excluded:** \`astral-sh/setup-uv\` left at v8.1.0 (v10 skips a major; held back for a separate review).
- **Untouched:** \`kitconcept/meta@main\` (branch pin, intentional).
- The three \`actions/*\` bumps are single-major and low risk. \`JarvusInnovations/background-action\` v1 → v2 is a major bump worth a glance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)