### PR TITLE
Add Playwright acceptance test setup

### DIFF
--- a/.github/workflows/frontend-playwright.yml
+++ b/.github/workflows/frontend-playwright.yml
@@ -1,0 +1,92 @@
+name: Playwright Acceptance Tests
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+      image-name-prefix:
+        required: true
+        type: string
+      image-tag:
+        required: true
+        type: string
+
+defaults:
+  run:
+    working-directory: ./frontend
+
+jobs:
+  playwright-acceptance:
+    name: Playwright Acceptance
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Load images
+        run: |
+          docker pull ${{ inputs.image-name-prefix }}-backend-acceptance:${{ inputs.image-tag }}
+          docker pull ${{ inputs.image-name-prefix }}-frontend:${{ inputs.image-tag }}
+          docker image ls -a
+
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Enable corepack
+        run: npm i -g corepack@latest && corepack enable
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v5
+        name: Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: make install
+
+      - name: Install Playwright browsers
+        run: pnpm exec playwright install --with-deps chromium
+
+      - uses: JarvusInnovations/background-action@v1.0.7
+        name: Start Servers - Volto and Plone (acceptance)
+        with:
+          run: |
+            docker run -i --net=host --rm --name=backend ${{ inputs.image-name-prefix }}-backend-acceptance:${{ inputs.image-tag }} &
+            docker run -i --net=host --rm --name=frontend -e RAZZLE_INTERNAL_API_PATH=http://127.0.0.1:55001/plone ${{ inputs.image-name-prefix }}-frontend:${{ inputs.image-tag }} &
+
+          wait-on: |
+            http-get://localhost:55001/plone
+            http://localhost:3000
+
+          tail: true # true = stderr,stdout
+
+          log-output-resume: stderr
+
+          wait-for: 10m
+
+          log-output: stderr,stdout # same as true
+
+          log-output-if: failure
+
+      - name: Run Playwright acceptance tests
+        run: pnpm exec playwright test -c playwright-acceptance.config.ts --reporter=list,html
+
+      - name: Upload Playwright artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: playwright-acceptance-report
+          path: |
+            frontend/playwright-report
+            frontend/acceptance/results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,6 +155,19 @@ jobs:
       image-tag: ${{ needs.config.outputs.base-tag }}
       a11y: ${{ matrix.a11y || false }}
 
+  playwright-acceptance:
+    name: "Playwright Acceptance"
+    if: ${{ needs.config.outputs.acceptance == 'true' && (always() && !contains(needs.*.result, 'failure'))}}
+    uses: ./.github/workflows/frontend-playwright.yml
+    needs:
+      - config
+      - backend-build
+      - frontend-build
+    with:
+      node-version: ${{ needs.config.outputs.node-version }}
+      image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
+      image-tag: ${{ needs.config.outputs.base-tag }}
+
   storybook:
     name: "Storybook Build"
     if: ${{ needs.config.outputs.acceptance == 'true' && (always() && !contains(needs.*.result, 'failure'))}}
@@ -195,6 +208,7 @@ jobs:
     needs:
       - config
       - acceptance
+      - playwright-acceptance
       - backend-build
       - visual-regression
     with:
@@ -213,6 +227,7 @@ jobs:
       - config
       - frontend-build
       - acceptance
+      - playwright-acceptance
       - visual-regression
     with:
       base-tag: ${{ needs.config.outputs.base-tag }}
@@ -272,6 +287,7 @@ jobs:
       - frontend-i18n
       - frontend-build
       - acceptance
+      - playwright-acceptance
       - visual-regression
       - backend-release
       - frontend-release
@@ -293,6 +309,7 @@ jobs:
           echo '| frontend-i18n | ${{ needs.frontend-i18n.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| frontend-build | ${{ needs.frontend-build.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| acceptance | ${{ needs.acceptance.result }} |' >> $GITHUB_STEP_SUMMARY
+          echo '| playwright-acceptance | ${{ needs.playwright-acceptance.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| visual-regression | ${{ needs.visual-regression.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| backend-release | ${{ needs.backend-release.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| frontend-release | ${{ needs.frontend-release.result }} |' >> $GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,130 @@
+# AGENTS.md
+
+This file applies to the repository root and all subdirectories unless a deeper `AGENTS.md` overrides it.
+When working inside `frontend/core`, always read the closer Volto `AGENTS.md` files there first.
+
+## Repository Overview
+
+This repository is the `volto-light-theme` (VLT) monorepo: a Volto theme add-on shipped with a supporting backend, frontend workspace, docs, and deployment support.
+It is split into three main working areas plus project-wide tooling:
+
+- `backend/` - Plone backend, policy/distribution package, Python toolchain, site creation/export helpers
+- `frontend/` - Volto-based frontend workspace, including the `@kitconcept/volto-light-theme` add-on package and acceptance tests
+- `docs/` - project documentation
+- `devops/`, `docker-compose*.yml`, root `Makefile` - deployment, local stack, CI, and orchestration
+
+## Monorepo Rules
+
+- The product is the `@kitconcept/volto-light-theme` add-on (published standalone to npm); the `backend/` and the rest of `frontend/` are the development and testing harness around it. Treat backend/frontend as a coordinated setup for developing and testing the add-on, not as a separate distribution.
+- Prefer the root `Makefile` for cross-stack tasks and the local `backend/` or `frontend/` Makefiles for area-specific work.
+- Use `pnpm`; do not introduce `npm` or top-level `yarn` workflows.
+- Keep changes scoped to the relevant area. Do not touch both backend and frontend unless the feature or bug actually spans both.
+- Preserve existing generated/example content workflows in `backend/`; exported content can be intentional product data, not disposable fixtures.
+
+## Frontend Model
+
+- `frontend/` is a pnpm workspace with a local Volto development setup.
+- The main project package is `frontend/packages/volto-light-theme`.
+- Most project-specific frontend work lives under `frontend/packages/volto-light-theme/src`.
+- `frontend/core` is a vendored Volto core workspace. Do not touch it for normal repo work; treat it as upstream core Volto code that is out of scope unless the user explicitly asks for a core Volto change.
+- Customizations, block configuration, theme styles, slots, and acceptance coverage are all part of the frontend package surface and often need coordinated updates.
+
+## Default Validation Commands
+
+Run the narrowest command set that matches the area you changed.
+
+Whole repo:
+
+```sh
+make format
+make lint
+make test
+```
+
+Frontend only:
+
+```sh
+make -C frontend format
+make -C frontend lint
+make -C frontend test
+```
+
+Backend only:
+
+```sh
+make -C backend format
+make -C backend lint
+make -C backend test
+```
+
+## Post-Edit Rule
+
+- After any code edit, run the linting and formatting pass for the affected area before finishing.
+- For frontend changes, that means at minimum:
+
+```sh
+make -C frontend format
+make -C frontend lint
+```
+
+- For backend changes, run the backend equivalents.
+- If a change spans both stacks, run the root `make format` and `make lint`.
+
+## Acceptance Tests
+
+There are two acceptance-test paths in this repo:
+
+- Cypress: the established, comprehensive acceptance and a11y suite (run by the `acceptance` matrix in CI)
+- Playwright: a newer path, added for future acceptance coverage
+
+Prefer Playwright for new acceptance coverage. Cypress remains the primary suite today and is still fully supported; keep existing Cypress specs working and extend them when a scenario is not yet covered by the Playwright setup.
+
+Primary Playwright commands:
+
+```sh
+make ci-acceptance-playwright-test          # CI mode: start acceptance containers, run headless, stop
+make -C frontend acceptance-playwright-test # interactive (UI) mode against already-running servers
+```
+
+You can also run the Playwright CLI directly from `frontend/`:
+
+```sh
+pnpm test:acceptance      # headless
+pnpm test:acceptance:ui   # interactive UI
+```
+
+Playwright tests live under `frontend/acceptance/tests`.
+They run through `frontend/playwright-acceptance.config.ts` (kept separate from the visual-regression `frontend/playwright.config.ts`) and are configured serially (`workers: 1`) because tests can conflict while creating and deleting content.
+Accessibility assertions are built into the Playwright tests via the `expectNoAccessibilityViolations` helper (`frontend/acceptance/tests/accessibility.ts`); there is no separate Playwright a11y command.
+
+Cypress commands:
+
+```sh
+make -C frontend acceptance-test
+make -C frontend ci-acceptance-test
+make -C frontend acceptance-a11y-test
+make -C frontend ci-acceptance-a11y-test
+```
+
+Cypress specs live under `frontend/cypress/tests`.
+
+## Editing Rules
+
+- Read the nearest `AGENTS.md` before editing.
+- Preserve the existing `Makefile`-driven workflows; do not replace them with ad hoc commands in docs or automation without a reason.
+- Be careful with `mrs.developer.json`, local workspace overrides, and the vendored/frontend core relationship.
+- When changing frontend behavior, consider whether the change belongs in `frontend/packages/volto-light-theme` or in the vendored Volto core area.
+- When changing exported backend content or distribution setup, verify whether the change affects demo data, installation defaults, or test fixtures.
+
+## Changelog Fragments
+
+This repo checks for towncrier fragments in CI.
+
+- Backend changes need a fragment under `backend/news/`
+- Frontend add-on changes need a fragment under `frontend/packages/volto-light-theme/news/`
+- Repo-level (not related to `backend` or `frontend`) changes may need a fragment under the root `news/`
+
+## PR Guidance
+
+- Create a PR only when you are told to
+- After creating a PR, make sure that a Towncrier fragment is present for the change, and that it is in the correct location. Create it/them if needed following the Changelog Fragments guidance section.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+See [AGENTS.md](./AGENTS.md) for the repository guidance and working conventions.

--- a/Makefile
+++ b/Makefile
@@ -256,6 +256,23 @@ ci-acceptance-test:
 	$(MAKE) acceptance-containers-stop
 
 ###########################################
+# Playwright Acceptance Tests
+###########################################
+
+.PHONY: acceptance-playwright-test
+acceptance-playwright-test: ## Start Playwright acceptance tests in interactive (UI) mode
+	@echo "Start Playwright acceptance tests in interactive mode"
+	$(MAKE) -C "./frontend/" acceptance-playwright-test
+
+.PHONY: ci-acceptance-playwright-test
+ci-acceptance-playwright-test: ## Run Playwright acceptance tests against the acceptance containers in CI mode
+	@echo "Run Playwright acceptance tests in CI mode"
+	$(MAKE) acceptance-containers-start
+	pnpm dlx wait-on --httpTimeout 20000 http-get://localhost:55001/plone http://localhost:3000
+	$(MAKE) -C "./frontend/" ci-acceptance-playwright-test
+	$(MAKE) acceptance-containers-stop
+
+###########################################
 # A11y Tests
 ###########################################
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -10,6 +10,10 @@ public
 pyvenv.cfg
 docs/_build
 cypress/downloads/
+acceptance/results/
+playwright/results/
+playwright-report/
+test-results/
 
 packages/*
 !packages/volto-light-theme

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -145,6 +145,19 @@ ci-acceptance-backend-start: ## Start backend acceptance server in headless mode
 acceptance-test: ## Start Cypress in interactive mode
 	pnpm --filter @plone/volto exec cypress open --config-file $(CURRENT_DIR)/cypress.config.js --config specPattern=$(CURRENT_DIR)'/cypress/tests/**/*.{js,jsx,ts,tsx}'
 
+## Playwright acceptance tests
+.PHONY: install-playwright
+install-playwright: ## Install the Playwright browsers used by the acceptance tests
+	pnpm exec playwright install --with-deps chromium
+
+.PHONY: acceptance-playwright-test
+acceptance-playwright-test: ## Start Playwright acceptance tests in interactive (UI) mode
+	pnpm exec playwright test -c $(CURRENT_DIR)/playwright-acceptance.config.ts --ui
+
+.PHONY: ci-acceptance-playwright-test
+ci-acceptance-playwright-test: ## Run Playwright acceptance tests in headless mode for CI
+	pnpm exec playwright test -c $(CURRENT_DIR)/playwright-acceptance.config.ts --reporter=list,html
+
 .PHONY: ci-acceptance-test
 ci-acceptance-test: ## Run cypress tests in headless mode for CI
 	pnpm --filter @plone/volto exec cypress run --config-file $(CURRENT_DIR)/cypress.config.js --config specPattern='$(SPEC)'

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -23,3 +23,4 @@ You can find the documentation of this package at https://volto-light-theme.read
 ## Upgrade Guide
 
 See a detailed upgrade guide at https://volto-light-theme.readthedocs.io/latest/upgrade-guide.html.
+

--- a/frontend/acceptance/README.md
+++ b/frontend/acceptance/README.md
@@ -1,0 +1,54 @@
+# Playwright acceptance tests
+
+End-to-end acceptance tests driven by [Playwright](https://playwright.dev/),
+running against a Plone **acceptance** backend (with `RobotRemote` enabled, so
+the backend can be reset between tests) and a running Volto frontend.
+
+These are separate from the visual regression tests (`../playwright`), which use
+their own `playwright.config.ts`. Acceptance tests use
+`../playwright-acceptance.config.ts` and live in `tests/`.
+
+## Layout
+
+- `tests/reset-fixture.ts` — `setup`/`teardown` helpers that call `RobotRemote`
+  to reset the backend ZODB to a known state.
+- `tests/test.ts` — the extended `test`/`expect`. Provides an auto `resetBackend`
+  fixture that tears down and sets up the backend around every test.
+- `tests/login.ts` — `login(page)`, authenticates via `@login` and sets the
+  `auth_token` cookie (equivalent to Cypress' `cy.autologin`).
+- `tests/content.ts` — `createContent(...)`, creates content through the REST
+  API (equivalent to `cy.createContent`).
+- `tests/accessibility.ts` — `expectNoAccessibilityViolations(page, ...)`, an
+  axe-core based accessibility assertion.
+- `tests/*.test.ts` — the tests themselves.
+
+## Configuration
+
+The helpers read the following environment variables (with sensible defaults for
+the acceptance backend):
+
+- `BACKEND_HOST` (default `127.0.0.1`)
+- `SITE_ID` (default `plone`)
+- `API_PATH` (default `http://${BACKEND_HOST}:55001/${SITE_ID}`)
+- `FRONTEND_URL` (default `http://localhost:3000`)
+
+## Running locally
+
+From the repository root, start the acceptance containers and run the suite:
+
+```bash
+make ci-acceptance-playwright-test
+```
+
+To iterate interactively (with the Playwright UI) against already-running
+servers, start the acceptance backend and frontend, then:
+
+```bash
+make acceptance-playwright-test
+```
+
+The first time, install the browsers used by Playwright:
+
+```bash
+make -C frontend install-playwright
+```

--- a/frontend/acceptance/tests/accessibility.ts
+++ b/frontend/acceptance/tests/accessibility.ts
@@ -1,0 +1,48 @@
+import AxeBuilder from '@axe-core/playwright';
+import { expect, type Page } from '@playwright/test';
+import type { RunOptions, SerialFrameSelector } from 'axe-core';
+
+type AccessibilityCheckOptions = {
+  include?: SerialFrameSelector[];
+  exclude?: SerialFrameSelector[];
+  axeOptions?: RunOptions;
+  disabledRules?: string[];
+};
+
+export async function expectNoAccessibilityViolations(
+  page: Page,
+  options: AccessibilityCheckOptions = {},
+) {
+  const builder = new AxeBuilder({ page });
+
+  for (const selector of options.include ?? []) {
+    builder.include(selector);
+  }
+
+  for (const selector of options.exclude ?? []) {
+    builder.exclude(selector);
+  }
+
+  if (options.axeOptions) {
+    builder.options(options.axeOptions);
+  }
+
+  if (options.disabledRules?.length) {
+    builder.disableRules(options.disabledRules);
+  }
+
+  const { violations } = await builder.analyze();
+
+  const violationSummary = violations.map((violation) => ({
+    id: violation.id,
+    impact: violation.impact,
+    description: violation.description,
+    help: violation.help,
+    nodes: violation.nodes.map((node) => ({
+      target: node.target,
+      failureSummary: node.failureSummary,
+    })),
+  }));
+
+  expect(violationSummary).toEqual([]);
+}

--- a/frontend/acceptance/tests/content.test.ts
+++ b/frontend/acceptance/tests/content.test.ts
@@ -1,0 +1,29 @@
+import { login } from './login';
+import { expect, test } from './test';
+import { createContent } from './content';
+
+test.describe('Content', () => {
+  test('a published Document created via the API is viewable', async ({
+    page,
+  }) => {
+    await login(page);
+
+    const contentId = `acceptance-document-${Date.now()}`;
+    await createContent(page, {
+      contentType: 'Document',
+      contentId,
+      contentTitle: 'Acceptance Document',
+      path: '',
+      transition: 'publish',
+    });
+
+    const response = await page.goto(`/${contentId}`, {
+      waitUntil: 'networkidle',
+    });
+
+    expect(response?.ok()).toBeTruthy();
+    await expect(
+      page.getByRole('heading', { name: 'Acceptance Document' }),
+    ).toBeVisible();
+  });
+});

--- a/frontend/acceptance/tests/content.ts
+++ b/frontend/acceptance/tests/content.ts
@@ -1,0 +1,140 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+
+export type RequestOptions = {
+  apiURL?: string;
+  username?: string;
+  password?: string;
+};
+
+export type CreateContentParams = {
+  contentType: string;
+  contentId: string;
+  contentTitle: string;
+  contentDescription?: string;
+  path?: string;
+  allow_discussion?: boolean;
+  transition?: string;
+  bodyModifier?: (body: Record<string, unknown>) => Record<string, unknown>;
+};
+
+function getRequestContext(requestOrPage: APIRequestContext | Page) {
+  if ('request' in requestOrPage) return requestOrPage.request;
+  return requestOrPage;
+}
+
+function getDefaultApiConfig(options: RequestOptions) {
+  const hostname = process.env.BACKEND_HOST || '127.0.0.1';
+  const siteId = process.env.SITE_ID || 'plone';
+
+  const apiURL =
+    options.apiURL ||
+    process.env.API_PATH ||
+    `http://${hostname}:55001/${siteId}`;
+
+  const username = options.username || 'admin';
+  const password = options.password || 'secret';
+
+  return { apiURL, username, password };
+}
+
+function basicAuthHeader(username: string, password: string) {
+  const token = Buffer.from(`${username}:${password}`, 'utf8').toString(
+    'base64',
+  );
+  return `Basic ${token}`;
+}
+
+function normalizePath(value?: string) {
+  if (!value) return '';
+  return value.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * Creates content through the REST API (same behavior as cy.createContent).
+ * Content types that support blocks get a default title + slate scaffold,
+ * which can be overridden through `bodyModifier`.
+ */
+export async function createContent(
+  requestOrPage: APIRequestContext | Page,
+  {
+    contentType,
+    contentId,
+    contentTitle,
+    contentDescription = '',
+    path = '',
+    allow_discussion = false,
+    transition = '',
+    bodyModifier = (body) => body,
+  }: CreateContentParams,
+  requestOptions: RequestOptions = {},
+) {
+  const request = getRequestContext(requestOrPage);
+  const { apiURL, username, password } = getDefaultApiConfig(requestOptions);
+
+  const authHeader = basicAuthHeader(username, password);
+  const normalizedPath = normalizePath(path);
+  const containerUrl = `${apiURL}/${normalizedPath}`;
+
+  const defaultBody: Record<string, unknown> = {
+    '@type': contentType,
+    id: contentId,
+    title: contentTitle,
+    description: contentDescription,
+    allow_discussion,
+  };
+
+  let body: Record<string, unknown>;
+
+  if (['Document', 'News Item', 'Folder'].includes(contentType)) {
+    body = bodyModifier({
+      ...defaultBody,
+      blocks: {
+        'd3f1c443-583f-4e8e-a682-3bf25752a300': { '@type': 'title' },
+        '7624cf59-05d0-4055-8f55-5fd6597d84b0': { '@type': 'slate' },
+      },
+      blocks_layout: {
+        items: [
+          'd3f1c443-583f-4e8e-a682-3bf25752a300',
+          '7624cf59-05d0-4055-8f55-5fd6597d84b0',
+        ],
+      },
+    });
+  } else {
+    body = bodyModifier(defaultBody);
+  }
+
+  const response = await request.post(containerUrl, {
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: authHeader,
+    },
+    data: body,
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Create content failed: POST ${containerUrl} returned ${response.status()} ${response.statusText()}`,
+    );
+  }
+
+  if (transition) {
+    const normalizedId = normalizePath(contentId);
+    const url = `${apiURL}/${normalizedPath}/${normalizedId}/@workflow/${transition}`;
+
+    const transitionResponse = await request.post(url, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: authHeader,
+      },
+    });
+
+    if (!transitionResponse.ok()) {
+      throw new Error(
+        `Workflow transition failed: POST ${url} returned ${transitionResponse.status()} ${transitionResponse.statusText()}`,
+      );
+    }
+  }
+
+  return response;
+}

--- a/frontend/acceptance/tests/homepage.test.ts
+++ b/frontend/acceptance/tests/homepage.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from './test';
+import { expectNoAccessibilityViolations } from './accessibility';
+
+test.describe('Homepage', () => {
+  test('renders and has no automatic accessibility violations', async ({
+    page,
+  }) => {
+    const response = await page.goto('/', { waitUntil: 'networkidle' });
+
+    expect(response?.ok()).toBeTruthy();
+    await expect(page.getByRole('banner')).toBeVisible();
+
+    await expectNoAccessibilityViolations(page, {
+      // The example homepage intentionally omits an h1, matching the
+      // longstanding Cypress a11y baseline for this repo.
+      disabledRules: ['page-has-heading-one'],
+    });
+  });
+});

--- a/frontend/acceptance/tests/login.ts
+++ b/frontend/acceptance/tests/login.ts
@@ -1,0 +1,62 @@
+import type { Page } from '@playwright/test';
+
+export type LoginOptions = {
+  apiURL?: string;
+  frontendURL?: string;
+  username?: string;
+  password?: string;
+};
+
+const DEFAULT_PLONE_AUTH: [string, string] = ['admin', 'secret'];
+
+function getDefaults(options: LoginOptions) {
+  const hostname = process.env.BACKEND_HOST || '127.0.0.1';
+  const siteId = process.env.SITE_ID || 'plone';
+
+  const apiURL =
+    options.apiURL ||
+    process.env.API_PATH ||
+    `http://${hostname}:55001/${siteId}`;
+
+  const username = options.username || DEFAULT_PLONE_AUTH[0];
+  const password = options.password || DEFAULT_PLONE_AUTH[1];
+
+  const frontendURL =
+    options.frontendURL || process.env.FRONTEND_URL || 'http://localhost:3000';
+
+  return { apiURL, username, password, frontendURL };
+}
+
+/**
+ * Logs in by POSTing to `${apiURL}/@login` and setting the `auth_token`
+ * cookie in the current browser context (same behavior as cy.autologin).
+ */
+export async function login(page: Page, options: LoginOptions = {}) {
+  const { apiURL, username, password, frontendURL } = getDefaults(options);
+
+  const response = await page.request.post(`${apiURL}/@login`, {
+    headers: { Accept: 'application/json' },
+    data: { login: username, password },
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Login failed: POST ${apiURL}/@login returned ${response.status()} ${response.statusText()}`,
+    );
+  }
+
+  const body = (await response.json()) as { token?: string };
+  if (!body.token) {
+    throw new Error('Login failed: response did not include body.token');
+  }
+
+  await page.context().addCookies([
+    {
+      name: 'auth_token',
+      value: body.token,
+      url: frontendURL,
+    },
+  ]);
+
+  return { token: body.token };
+}

--- a/frontend/acceptance/tests/reset-fixture.ts
+++ b/frontend/acceptance/tests/reset-fixture.ts
@@ -1,0 +1,56 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+
+function getRequestContext(requestOrPage: APIRequestContext | Page) {
+  if ('request' in requestOrPage) return requestOrPage.request;
+  return requestOrPage;
+}
+
+function getDefaultApiURL() {
+  const hostname = process.env.BACKEND_HOST || '127.0.0.1';
+  const siteId = process.env.SITE_ID || 'plone';
+  return process.env.API_PATH || `http://${hostname}:55001/${siteId}`;
+}
+
+const ROBOT_HEADERS = { Accept: 'text/xml', 'content-type': 'text/xml' };
+
+const SETUP_BODY =
+  '<?xml version="1.0"?><methodCall><methodName>run_keyword</methodName><params><param><value><string>remote_zodb_setup</string></value></param><param><value><array><data><value><string>plone.app.robotframework.testing.PLONE_ROBOT_TESTING</string></value></data></array></value></param></params></methodCall>';
+
+const TEARDOWN_BODY =
+  '<?xml version="1.0"?><methodCall><methodName>run_keyword</methodName><params><param><value><string>remote_zodb_teardown</string></value></param><param><value><array><data><value><string>plone.app.robotframework.testing.PLONE_ROBOT_TESTING</string></value></data></array></value></param></params></methodCall>';
+
+async function callRobotRemote(
+  request: APIRequestContext,
+  apiURL: string,
+  body: string,
+) {
+  const url = `${apiURL}/RobotRemote`;
+  const response = await request.post(url, {
+    headers: ROBOT_HEADERS,
+    data: body,
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `RobotRemote call failed: POST ${url} returned ${response.status()} ${response.statusText()}`,
+    );
+  }
+
+  return response;
+}
+
+export async function setup(
+  requestOrPage: APIRequestContext | Page,
+  apiURL: string = getDefaultApiURL(),
+) {
+  const request = getRequestContext(requestOrPage);
+  return callRobotRemote(request, apiURL, SETUP_BODY);
+}
+
+export async function teardown(
+  requestOrPage: APIRequestContext | Page,
+  apiURL: string = getDefaultApiURL(),
+) {
+  const request = getRequestContext(requestOrPage);
+  return callRobotRemote(request, apiURL, TEARDOWN_BODY);
+}

--- a/frontend/acceptance/tests/test.ts
+++ b/frontend/acceptance/tests/test.ts
@@ -1,0 +1,28 @@
+import { expect, test as base } from '@playwright/test';
+
+import { setup, teardown } from './reset-fixture';
+
+type TestFixtures = {
+  resetBackend: void;
+};
+
+export const test = base.extend<TestFixtures>({
+  resetBackend: [
+    async ({ page, request }, use) => {
+      await teardown(request);
+      await setup(request);
+
+      try {
+        await use();
+      } finally {
+        // Close the live page before resetting the backend so teardown does
+        // not trigger refresh noise that obscures the real test failure.
+        await page.close().catch(() => {});
+        await teardown(request);
+      }
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,8 @@
     "storybook-build": "VOLTOCONFIG=$(pwd)/volto.config.js pnpm --filter @plone/volto build-storybook -c $(pwd)/.storybook",
     "test:visual": "playwright test playwright/tests/visual/main/*.test.{ts,tsx}",
     "test:visual:ui": "playwright test --ui",
+    "test:acceptance": "playwright test -c playwright-acceptance.config.ts",
+    "test:acceptance:ui": "playwright test -c playwright-acceptance.config.ts --ui",
     "update:browserlist": "pnpm --filter @plone/volto add caniuse-lite && pnpm --filter @plone/volto remove caniuse-lite"
   },
   "devDependencies": {

--- a/frontend/packages/volto-light-theme/news/+supportPlaywrightAcceptanceTests.feature
+++ b/frontend/packages/volto-light-theme/news/+supportPlaywrightAcceptanceTests.feature
@@ -1,0 +1,1 @@
+Add a Playwright-based acceptance test setup under `frontend/acceptance` (backend reset fixture, login/content/accessibility utilities and a basic test suite), with Makefile targets and a CI workflow to run them. @sneridagh

--- a/frontend/packages/volto-light-theme/package.json
+++ b/frontend/packages/volto-light-theme/package.json
@@ -49,6 +49,7 @@
     "@types/node": "^22",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.60.0",
     "playwright": "^1.60.0",
     "react-intl-redux": "2.3.0",

--- a/frontend/playwright-acceptance.config.ts
+++ b/frontend/playwright-acceptance.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Acceptance tests run against a Plone acceptance backend (RobotRemote enabled)
+// and a running Volto frontend. This config is intentionally separate from the
+// visual regression one (`playwright.config.ts`).
+export default defineConfig({
+  testDir: 'acceptance/tests',
+  testMatch: ['**/*.{spec,test}.{ts,tsx}'],
+  outputDir: 'acceptance/results',
+  // Disable parallel tests to avoid conflicts creating/deleting content while
+  // sharing a single backend that is reset between tests.
+  workers: 1,
+  // Fail the build on CI if you accidentally left test.only in the source code.
+  forbidOnly: !!process.env.CI,
+  // Retry on CI only.
+  retries: process.env.CI ? 3 : 0,
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    browserName: 'chromium',
+    viewport: { width: 1440, height: 1000 },
+    trace: 'retain-on-failure',
+    // Use video only while debugging CI
+    // video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+  ],
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -1746,6 +1746,9 @@ importers:
         specifier: ^11.0.0
         version: 11.1.0
     devDependencies:
+      '@axe-core/playwright':
+        specifier: ^4.12.1
+        version: 4.13.0(playwright-core@1.60.0)
       '@playwright/test':
         specifier: ^1.60.0
         version: 1.60.0
@@ -2036,6 +2039,11 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@axe-core/playwright@4.13.0':
+    resolution: {integrity: sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==}
+    peerDependencies:
+      playwright-core: '>= 1.0.0'
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -5746,6 +5754,10 @@ packages:
 
   axe-core@4.11.0:
     resolution: {integrity: sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==}
+    engines: {node: '>=4'}
+
+  axe-core@4.13.0:
+    resolution: {integrity: sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==}
     engines: {node: '>=4'}
 
   axe-core@4.4.2:
@@ -12356,6 +12368,11 @@ snapshots:
 
   '@asamuzakjp/nwsapi@2.3.9': {}
 
+  '@axe-core/playwright@4.13.0(playwright-core@1.60.0)':
+    dependencies:
+      axe-core: 4.13.0
+      playwright-core: 1.60.0
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -17122,6 +17139,8 @@ snapshots:
   axe-core@3.5.6: {}
 
   axe-core@4.11.0: {}
+
+  axe-core@4.13.0: {}
 
   axe-core@4.4.2: {}
 


### PR DESCRIPTION
## What

Sets up a Playwright-based acceptance test suite under `frontend/acceptance`, modeled on the setup introduced in [kitconcept.intranet#399](https://github.com/kitconcept/kitconcept.intranet/pull/399). It coexists with the existing Cypress acceptance suite and the Playwright *visual-regression* suite.

## Changes

- **`frontend/acceptance/tests/`** — reset fixture (`RobotRemote` ZODB setup/teardown), `login`, `createContent`, and `expectNoAccessibilityViolations` (axe-core) utilities, plus two basic tests: a homepage a11y check and an API content smoke test.
- **`frontend/playwright-acceptance.config.ts`** — dedicated config (`testDir: acceptance/tests`, `workers: 1`), kept separate from the visual-regression `playwright.config.ts`.
- **Makefile** — root `acceptance-playwright-test` / `ci-acceptance-playwright-test` (reusing the existing acceptance containers) and matching frontend targets; `test:acceptance` / `test:acceptance:ui` pnpm scripts.
- **CI** — new reusable `.github/workflows/frontend-playwright.yml`, wired into `main.yml` as a single (non-sharded) `Playwright Acceptance` job that runs against the acceptance backend image. Added to the release gates and the final report.
- **Deps** — `@axe-core/playwright` added to the inner add-on package (`frontend/packages/volto-light-theme`), hoisted via the existing `*playwright*` `.npmrc` pattern; `@playwright/test`/`playwright` were already there.
- **Docs** — corrected `AGENTS.md`/`CLAUDE.md`, which had been copied verbatim from kitconcept.intranet, to describe `volto-light-theme` accurately (package names, paths, acceptance commands, changelog-fragment locations).

## Notes

- The two tests pass config/import collection locally (`playwright test --list`); a full green run needs the acceptance backend + frontend running (`make ci-acceptance-playwright-test`).