### PR TITLE
updates volto to 19.4.0 and adjusts the search container width to layout

### DIFF
--- a/frontend/mrs.developer.json
+++ b/frontend/mrs.developer.json
@@ -4,7 +4,7 @@
     "package": "@plone/volto",
     "url": "git@github.com:plone/volto.git",
     "https": "https://github.com/plone/volto.git",
-    "tag": "19.3.0",
+    "tag": "19.4.0",
     "filterBlobs": true
   },
   "volto-banner-block": {

--- a/frontend/packages/volto-light-theme/news/+fixSearchContainerWidth.internal
+++ b/frontend/packages/volto-light-theme/news/+fixSearchContainerWidth.internal
@@ -1,0 +1,1 @@
+Adjusted the container-width of the search to be layout width. @TimoBroeskamp

--- a/frontend/packages/volto-light-theme/src/theme/_container.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_container.scss
@@ -1,3 +1,7 @@
+#page-search.q.container {
+  @include layout-container-width();
+}
+
 .q.container,
 .a.container {
   container-type: inline-size;

--- a/frontend/packages/volto-light-theme/src/theme/_container.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_container.scss
@@ -1,5 +1,5 @@
 #page-search.q.container {
-  @include layout-container-width();
+  @include default-container-width();
 }
 
 .q.container,

--- a/frontend/packages/volto-light-theme/src/theme/_search-page.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_search-page.scss
@@ -82,7 +82,7 @@
   }
   #content {
     #content-core {
-      max-width: var(--layout-container-width);
+      max-width: var(--default-container-width);
       &.layout-grid {
         // Person results
         .tileItem.personResultItem {

--- a/frontend/packages/volto-light-theme/src/theme/_search-page.scss
+++ b/frontend/packages/volto-light-theme/src/theme/_search-page.scss
@@ -82,7 +82,7 @@
   }
   #content {
     #content-core {
-      max-width: var(--default-container-width);
+      max-width: var(--layout-container-width);
       &.layout-grid {
         // Person results
         .tileItem.personResultItem {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -225,7 +225,7 @@ importers:
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))(typescript@5.9.3)
       '@tailwindcss/vite':
         specifier: 'catalog:'
-        version: 4.1.17(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 4.1.17(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))
       '@testing-library/jest-dom':
         specifier: 'catalog:'
         version: 6.9.1
@@ -243,7 +243,7 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 5.1.1(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 5.1.1(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4)
@@ -276,13 +276,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
       vite-plugin-svgr:
         specifier: ^4.3.0
-        version: 4.5.0(rollup@4.53.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 4.5.0(rollup@4.53.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   core/packages/coresandbox:
     dependencies:
@@ -385,10 +385,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   core/packages/scripts:
     dependencies:
@@ -868,7 +868,7 @@ importers:
         version: 7.18.0(eslint@8.57.1)(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))
+        version: 4.7.0(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))
       '@vitest/ui':
         specifier: 'catalog:'
         version: 3.2.4(vitest@3.2.4)
@@ -1057,7 +1057,7 @@ importers:
         version: 1.3.2
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
       wait-on:
         specifier: 'catalog:'
         version: 9.0.5(debug@4.3.4)
@@ -1233,6 +1233,9 @@ importers:
       terminate:
         specifier: ^2.1.2
         version: 2.8.0
+      terser:
+        specifier: 5.46.0
+        version: 5.46.0
       terser-webpack-plugin:
         specifier: 5.4.0
         version: 5.4.0(esbuild@0.25.12)(webpack@5.105.4(esbuild@0.25.12))
@@ -1260,7 +1263,7 @@ importers:
         version: 28.1.0
       vitest:
         specifier: 'catalog:'
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   core/packages/volto-razzle-dev-utils:
     dependencies:
@@ -1406,7 +1409,7 @@ importers:
         version: 17.1.1(typescript@5.9.3)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-bm3-compat/packages/volto-bm3-compat:
     dependencies:
@@ -1443,7 +1446,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-button-block/packages/volto-button-block:
     dependencies:
@@ -1498,7 +1501,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-calendar-block/packages/volto-calendar-block:
     dependencies:
@@ -1532,7 +1535,7 @@ importers:
         version: 19.0.6(@types/node@24.10.1)(magicast@0.3.5)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-carousel-block/packages/volto-carousel-block:
     dependencies:
@@ -1584,7 +1587,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-dsgvo-banner/packages/volto-dsgvo-banner:
     dependencies:
@@ -1609,7 +1612,7 @@ importers:
         version: 17.1.1(typescript@5.9.3)
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-heading-block/packages/volto-heading-block:
     dependencies:
@@ -1668,7 +1671,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-introduction-block/packages/volto-introduction-block:
     dependencies:
@@ -1687,7 +1690,7 @@ importers:
         version: 19.0.6(@types/node@24.10.1)(magicast@0.3.5)
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-light-theme:
     dependencies:
@@ -1802,7 +1805,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-logos-block/packages/volto-logos-block:
     dependencies:
@@ -1860,7 +1863,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-separator-block/packages/volto-separator-block:
     dependencies:
@@ -1909,7 +1912,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.1.2
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   packages/volto-slider-block/packages/volto-slider-block:
     dependencies:
@@ -1982,7 +1985,7 @@ importers:
         version: 13.0.0
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
 packages:
 
@@ -11383,6 +11386,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  terser@5.46.0:
+    resolution: {integrity: sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
@@ -16015,12 +16023,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.17
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.17
 
-  '@tailwindcss/vite@4.1.17(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@tailwindcss/vite@4.1.17(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.17
       '@tailwindcss/oxide': 4.1.17
       tailwindcss: 4.1.17
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   '@testing-library/cypress@10.1.0(cypress@15.6.0)':
     dependencies:
@@ -16617,7 +16625,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -16625,11 +16633,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.1(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitejs/plugin-react@5.1.1(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -16637,7 +16645,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.47
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16656,7 +16664,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16675,13 +16683,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   '@vitest/pretty-format@2.0.5':
     dependencies:
@@ -16724,7 +16732,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
 
   '@vitest/utils@2.0.5':
     dependencies:
@@ -19782,7 +19790,7 @@ snapshots:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.44.1
+      terser: 5.46.0
 
   html-tags@3.3.1: {}
 
@@ -21002,7 +21010,7 @@ snapshots:
 
   mlly@1.8.0:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
@@ -23770,6 +23778,13 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  terser@5.46.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.11
+      acorn: 8.16.0
+      commander: 2.20.3
+      source-map-support: 0.5.21
+
   test-exclude@7.0.1:
     dependencies:
       '@istanbuljs/schema': 0.1.3
@@ -24090,7 +24105,7 @@ snapshots:
 
   unplugin@1.16.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
@@ -24224,13 +24239,13 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
-  vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1):
+  vite-node@3.2.4(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -24245,18 +24260,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.5.0(rollup@4.53.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)):
+  vite-plugin-svgr@4.5.0(rollup@4.53.3)(typescript@5.9.3)(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.53.3)
       '@svgr/core': 8.1.0(typescript@5.9.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.3))
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1):
+  vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -24271,14 +24286,14 @@ snapshots:
       less: 3.13.1
       lightningcss: 1.30.2
       sass: 1.58.0
-      terser: 5.44.1
+      terser: 5.46.0
       yaml: 2.8.1
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.1)(@vitest/ui@3.2.4)(jiti@2.6.1)(jsdom@28.1.0)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -24296,8 +24311,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
-      vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.44.1)(yaml@2.8.1)
+      vite: 6.4.2(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.10.1)(jiti@2.6.1)(less@3.13.1)(lightningcss@1.30.2)(sass@1.58.0)(terser@5.46.0)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12


### PR DESCRIPTION
This PR sets the volto version to 19.4.0 because I need the change for the quanta container and adjusts the width of the search to layout with.