### PR TITLE
Adjust Blocks example content

### DIFF
--- a/backend/news/+adjust-block-example-content.internal
+++ b/backend/news/+adjust-block-example-content.internal
@@ -1,0 +1,1 @@
+Adjust the Blocks example content: add missing block descriptions (banner, carousel, event calendar, logos), add banner variations, add grey background variants (carousel, event calendar, maps), add an OpenStreetMap example to the maps block, and remove an orphaned block from the event calendar page.

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/4d844688c768462ab158fe0bdb80c098/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/4d844688c768462ab158fe0bdb80c098/data.json
@@ -250,7 +250,7 @@
   "creators": [
     "admin"
   ],
-  "description": "",
+  "description": "The logos block displays a grid of logos, optionally linked. Logos can be shown in different sizes (S / L) and container widths (default / layout).",
   "effective": null,
   "exclude_from_nav": false,
   "expires": null,

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/6f42321fa6cf4f57969c78a21f92dd79/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/6f42321fa6cf4f57969c78a21f92dd79/data.json
@@ -126,6 +126,252 @@
       ],
       "items_to_show": 2
     },
+    "75bbcbc4-319f-4174-97e4-441d94e489b6": {
+      "@type": "carousel",
+      "columns": [
+        {
+          "@id": "0ffd97f7-f9b0-4af3-8ef3-5e877e084ace",
+          "@type": "teaser",
+          "description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/99c70917b6894af08dd306fdbc0eff6a",
+              "@type": "Document",
+              "Description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+              "Title": "Grid",
+              "description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Grid",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Grid"
+        },
+        {
+          "@id": "5835ddff-447a-4e2f-9261-0bb8a7741409",
+          "@type": "teaser",
+          "description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/8416628543f146ff9a18d281c03e2399",
+              "@type": "Document",
+              "Description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+              "Title": "Highlight",
+              "description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Highlight",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Highlight"
+        },
+        {
+          "@id": "6aac2c57-897c-40d9-b372-afa9aa951b45",
+          "@type": "teaser",
+          "description": "The search block allows the content of the website to be listed. Users can use so-called facets to select certain properties of the listed content in order to filter them (e.g. filtering the news of 2022).",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/928010d84e5d4df2b2282f3e179d6b1a",
+              "@type": "Document",
+              "Description": "The search block allows the content of the website to be listed. Users can use so-called facets to select certain properties of the listed content in order to filter them (e.g. filtering the news of 2022).",
+              "Title": "Search",
+              "description": "The search block allows the content of the website to be listed. Users can use so-called facets to select certain properties of the listed content in order to filter them (e.g. filtering the news of 2022).",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Search",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Search"
+        },
+        {
+          "@id": "2832cfe6-49af-46ed-b99f-8895643fca05",
+          "@type": "teaser",
+          "description": " The Text Block allows you to add text to a web page. The text can be formatted and structured in different ways (bold, headings, etc.).",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/2508797173824f0e9f82bb2e7cfe922d",
+              "@type": "Document",
+              "Description": " The Text Block allows you to add text to a web page. The text can be formatted and structured in different ways (bold, headings, etc.).",
+              "Title": "Text",
+              "description": " The Text Block allows you to add text to a web page. The text can be formatted and structured in different ways (bold, headings, etc.).",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Text",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Text"
+        }
+      ],
+      "items_to_show": 4,
+      "theme": "grey"
+    },
+    "92e965e0-14d6-4511-88a7-761e740cada8": {
+      "@type": "carousel",
+      "columns": [
+        {
+          "@id": "346b24ac-564a-4019-931b-4c819ec31f29",
+          "@type": "teaser",
+          "description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/99c70917b6894af08dd306fdbc0eff6a",
+              "@type": "Document",
+              "Description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+              "Title": "Grid",
+              "description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Grid",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Grid"
+        },
+        {
+          "@id": "5170c124-9357-44d3-ab88-ed7aa383978d",
+          "@type": "teaser",
+          "description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/8416628543f146ff9a18d281c03e2399",
+              "@type": "Document",
+              "Description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+              "Title": "Highlight",
+              "description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Highlight",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Highlight"
+        },
+        {
+          "@id": "6e6295ef-c794-484a-9348-483affcfaf62",
+          "@type": "teaser",
+          "description": " The image block allows images to be embedded in various display formats. Images can be displayed in different sizes (100%, L, M, S) and aligned left, right or center of the text flow.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/40a436ad604f4f80aeafe0977806760a",
+              "@type": "Document",
+              "Description": " The image block allows images to be embedded in various display formats. Images can be displayed in different sizes (100%, L, M, S) and aligned left, right or center of the text flow.",
+              "Title": "Image",
+              "description": " The image block allows images to be embedded in various display formats. Images can be displayed in different sizes (100%, L, M, S) and aligned left, right or center of the text flow.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Image",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Image"
+        },
+        {
+          "@id": "a0fdac09-ef68-4efa-a645-99e7bc5b2152",
+          "@type": "teaser",
+          "description": " The introductory block allows the display of an introductory text, which is displayed larger than normal continuous text.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/00cef5f245a342958288ace545e3c097",
+              "@type": "Document",
+              "Description": " The introductory block allows the display of an introductory text, which is displayed larger than normal continuous text.",
+              "Title": "Introduction",
+              "description": " The introductory block allows the display of an introductory text, which is displayed larger than normal continuous text.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Introduction",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": true,
+          "title": "Introduction"
+        }
+      ],
+      "items_to_show": 2,
+      "theme": "grey"
+    },
     "996011d6-0a13-4dad-9a67-64d04ddb3728": {
       "@type": "carousel",
       "columns": [
@@ -367,6 +613,147 @@
     "a505fb79-d58b-4c21-9c2a-379185233c66": {
       "@type": "title"
     },
+    "b1a787f2-f142-4e25-9844-356fcadbec95": {
+      "@type": "slate",
+      "plaintext": "The same carousels displayed on a grey background.",
+      "styles": {},
+      "theme": "grey",
+      "value": [
+        {
+          "children": [
+            {
+              "text": "The same carousels displayed on a grey background."
+            }
+          ],
+          "type": "p"
+        }
+      ]
+    },
+    "b73465c2-e160-4459-b4c5-b5ab026e45f2": {
+      "@type": "carousel",
+      "columns": [
+        {
+          "@id": "19427d4d-bec1-4ccf-853a-fe42bbd2489b",
+          "@type": "teaser",
+          "description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/8416628543f146ff9a18d281c03e2399",
+              "@type": "Document",
+              "Description": " The highlight block allows you to highlight and tease a single piece of content. The content is displayed with a large image and a title and description in a banderole.",
+              "Title": "Highlight",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "title": "Highlight"
+            }
+          ],
+          "overwrite": true,
+          "title": "Highlight"
+        },
+        {
+          "@id": "252f3f0c-8a1e-46f9-bfe7-cbede4e08c92",
+          "@type": "teaser",
+          "description": "The teaser block allows you to add an element that teases existing website content with an image, a title and a description.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/bd2b39d2745847db82ed197a4eb1effc",
+              "@type": "Document",
+              "Description": "The teaser block allows you to add an element that teases existing website content with an image, a title and a description.",
+              "Title": "Teaser",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "title": "Teaser"
+            }
+          ],
+          "overwrite": true,
+          "title": "Teaser"
+        },
+        {
+          "@id": "c5ad0405-c632-4afb-a176-22bac69ee206",
+          "@type": "teaser",
+          "description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/99c70917b6894af08dd306fdbc0eff6a",
+              "@type": "Document",
+              "Description": " The Grid block allows adding multi-column blocks. A grid block can contain between one and four columns of different blocks. Teasers and images can be added in a grid block.",
+              "Title": "Grid",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "title": "Grid"
+            }
+          ],
+          "overwrite": true,
+          "title": "Grid"
+        },
+        {
+          "@id": "05dc8b0c-9a66-480b-b148-4d2195bdec46",
+          "@type": "teaser",
+          "description": " The image block allows images to be embedded in various display formats. Images can be displayed in different sizes (100%, L, M, S) and aligned left, right or center of the text flow.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/40a436ad604f4f80aeafe0977806760a",
+              "@type": "Document",
+              "Description": " The image block allows images to be embedded in various display formats. Images can be displayed in different sizes (100%, L, M, S) and aligned left, right or center of the text flow.",
+              "Title": "Image",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "title": "Image"
+            }
+          ],
+          "overwrite": true,
+          "title": "Image"
+        },
+        {
+          "@id": "3eeb8f19-413f-474c-923d-8ba34f8becda",
+          "@type": "teaser",
+          "description": "The Page content type can be used to display content on a single page of the website. Pages can be structured using text, images and blocks.",
+          "head_title": null,
+          "href": [
+            {
+              "@id": "../../resolveuid/7ab9c48ede33415fa2a66a99549c8f70",
+              "@type": "Document",
+              "Description": "The Page content type can be used to display content on a single page of the website. Pages can be structured using text, images and blocks.",
+              "Title": "Page",
+              "description": "The Page content type can be used to display content on a single page of the website. Pages can be structured using text, images and blocks.",
+              "effective": "2023-07-06T18:35:00+00:00",
+              "end": null,
+              "getObjSize": "676.8 KB",
+              "hasPreviewImage": true,
+              "head_title": null,
+              "image_field": "preview_image_link",
+              "mime_type": "text/plain",
+              "nav_title": null,
+              "review_state": "published",
+              "start": null,
+              "title": "Page",
+              "type_title": "Page"
+            }
+          ],
+          "overwrite": false,
+          "title": "Page"
+        }
+      ],
+      "hide_description": true,
+      "items_to_show": 2,
+      "theme": "grey"
+    },
+    "b8fdb122-142f-44c6-a7ae-f85d994c3086": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Grey Background",
+      "styles": {},
+      "tag": "h2",
+      "theme": "grey"
+    },
     "c42eb567-8ebc-4da7-a956-7ab9a8930e6f": {
       "@type": "heading",
       "alignment": "left",
@@ -382,7 +769,12 @@
       "6cab1b9d-082a-4eef-8151-5b117af7544d",
       "996011d6-0a13-4dad-9a67-64d04ddb3728",
       "c42eb567-8ebc-4da7-a956-7ab9a8930e6f",
-      "a4094140-b4dd-4edc-acf5-7cf5ca0c656e"
+      "a4094140-b4dd-4edc-acf5-7cf5ca0c656e",
+      "b8fdb122-142f-44c6-a7ae-f85d994c3086",
+      "b1a787f2-f142-4e25-9844-356fcadbec95",
+      "92e965e0-14d6-4511-88a7-761e740cada8",
+      "75bbcbc4-319f-4174-97e4-441d94e489b6",
+      "b73465c2-e160-4459-b4c5-b5ab026e45f2"
     ]
   },
   "changeNote": "",
@@ -391,7 +783,7 @@
   "creators": [
     "admin"
   ],
-  "description": "",
+  "description": "The carousel block shows a horizontally scrolling row of teaser cards. Editors can configure the number of items to show, an optional headline and whether the descriptions are displayed.",
   "effective": "2025-07-23T12:08:00+00:00",
   "exclude_from_nav": false,
   "expires": null,

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/77de6a96dadf457e8091cc4fee063273/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/77de6a96dadf457e8091cc4fee063273/data.json
@@ -4,6 +4,22 @@
   "UID": "77de6a96dadf457e8091cc4fee063273",
   "allow_discussion": null,
   "blocks": {
+    "0144efb9-898d-4c3c-b3ce-e11f0994993b": {
+      "@type": "slate",
+      "plaintext": "The event calendar block displayed on a grey background.",
+      "styles": {},
+      "theme": "grey",
+      "value": [
+        {
+          "children": [
+            {
+              "text": "The event calendar block displayed on a grey background."
+            }
+          ],
+          "type": "p"
+        }
+      ]
+    },
     "0a4d6119-8af5-42dd-8a7f-43db3849693d": {
       "@type": "title"
     },
@@ -28,17 +44,42 @@
       "showSearchInput": true,
       "showTotalResults": true
     },
-    "undefined": {
+    "63cac87e-d31c-4228-b166-8fa21f7c9e3f": {
       "@type": "eventCalendar",
+      "facets": [
+        {
+          "@id": "b9d65d97-8032-4c81-9adb-a76bbb8381ec",
+          "advanced": false,
+          "field": {
+            "label": "Review state",
+            "value": "review_state"
+          },
+          "hidden": false,
+          "multiple": false,
+          "type": "selectFacet"
+        }
+      ],
       "showSearchInput": true,
-      "showTotalResults": true
+      "showTotalResults": true,
+      "theme": "grey"
+    },
+    "9fd93601-24b3-4471-890c-ee758f351ace": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Grey Background",
+      "styles": {},
+      "tag": "h2",
+      "theme": "grey"
     }
   },
   "blocks_layout": {
     "items": [
       "0a4d6119-8af5-42dd-8a7f-43db3849693d",
       "5175502b-8c90-4864-8bb1-ab9a974bebf1",
-      "18bde631-0220-45c8-9783-9f788845d2ac"
+      "18bde631-0220-45c8-9783-9f788845d2ac",
+      "9fd93601-24b3-4471-890c-ee758f351ace",
+      "0144efb9-898d-4c3c-b3ce-e11f0994993b",
+      "63cac87e-d31c-4228-b166-8fa21f7c9e3f"
     ]
   },
   "changeNote": "",
@@ -47,7 +88,7 @@
   "creators": [
     "admin"
   ],
-  "description": "",
+  "description": "The event calendar block can be used to search and display events in a listing format.",
   "effective": "2025-07-02T13:56:00+00:00",
   "exclude_from_nav": false,
   "expires": null,

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/912873ca2dae4228aa6c87c620a6bd85/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/912873ca2dae4228aa6c87c620a6bd85/data.json
@@ -4,57 +4,101 @@
   "UID": "912873ca2dae4228aa6c87c620a6bd85",
   "allow_discussion": null,
   "blocks": {
-    "0bd74992-e471-43f8-823e-32eb002969f3": {
-      "@type": "heading",
-      "heading": "\u00a0Full Width",
-      "styles": {},
-      "theme": "default"
-    },
-    "517a844e-983d-4ce1-969b-ecc813d36cf6": {
+    "0d953cb3-a685-450d-ac6f-a7930eb766b6": {
       "@type": "banner",
-      "additionalText": "Test line nao. 2 Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development.",
-      "styles": {
-        "blockWidth:noprefix": {
-          "--block-width": "100%"
-        }
-      },
-      "text": "Test line no. 1",
-      "theme": "default",
-      "url": "../../resolveuid/eec82559bf3242a6be4d43bc2096f399"
-    },
-    "619a853d-8f33-4c54-9059-e080aadba1d2": {
-      "@type": "banner",
-      "additionalText": "Test line nao. 2 Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development.",
+      "additionalText": "Test line no. 2 Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development.",
+      "alt": "",
       "styles": {
         "blockWidth:noprefix": {
           "--block-width": "var(--layout-container-width)"
         }
       },
-      "text": "Test line no. 1",
-      "theme": "default",
+      "text": "Layout width banner",
       "url": "../../resolveuid/970ec24c76784c66a06d8c8d8b6522b2"
     },
-    "6cd1475b-9778-4874-b95f-5bcf3f50d01a": {
+    "1f15b617-62a0-42ef-a7f3-e69eb3bdbb63": {
       "@type": "heading",
-      "heading": "Layout Width",
+      "alignment": "left",
+      "heading": "Grey Background",
       "styles": {},
+      "tag": "h2",
+      "theme": "grey"
+    },
+    "349e24be-d823-4b9c-bf41-0a3c3b03082d": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Full width, two lines",
+      "styles": {},
+      "tag": "h2",
       "theme": "default"
     },
     "879e7fd7-ef4b-47dd-a8ae-8b7b72a2255a": {
       "@type": "title"
     },
-    "9e02b7c4-c50b-40e0-99f4-65cea53ff2ac": {
-      "@type": "slate"
+    "97a9cb14-639a-4fb0-aadd-647f27f7e858": {
+      "@type": "banner",
+      "additionalText": "Test line no. 2 Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development.",
+      "alt": "",
+      "styles": {
+        "blockWidth:noprefix": {
+          "--block-width": "100%"
+        }
+      },
+      "text": "Banner on grey background",
+      "theme": "grey",
+      "url": "../../resolveuid/970ec24c76784c66a06d8c8d8b6522b2"
+    },
+    "9f9d4eee-3baa-4473-9b4e-a7d5bc83255d": {
+      "@type": "banner",
+      "additionalText": "Test line no. 2 Lorem ipsum is a dummy or placeholder text commonly used in graphic design, publishing, and web development.",
+      "alt": "",
+      "styles": {
+        "blockWidth:noprefix": {
+          "--block-width": "100%"
+        }
+      },
+      "text": "Full width banner",
+      "url": "../../resolveuid/970ec24c76784c66a06d8c8d8b6522b2"
+    },
+    "a3748dbd-b764-42bf-a3af-85b694fff3cc": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Layout width, two lines",
+      "styles": {},
+      "tag": "h2",
+      "theme": "default"
+    },
+    "b3768ee6-622f-455f-b380-974ef41196db": {
+      "@type": "banner",
+      "alt": "",
+      "styles": {
+        "blockWidth:noprefix": {
+          "--block-width": "100%"
+        }
+      },
+      "text": "Single line banner",
+      "url": "../../resolveuid/970ec24c76784c66a06d8c8d8b6522b2"
+    },
+    "dec34f08-9806-499e-97e6-2399c96f95e7": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Full width, single line",
+      "styles": {},
+      "tag": "h2",
+      "theme": "default"
     }
   },
   "blocks_layout": {
     "items": [
       "879e7fd7-ef4b-47dd-a8ae-8b7b72a2255a",
-      "6cd1475b-9778-4874-b95f-5bcf3f50d01a",
-      "619a853d-8f33-4c54-9059-e080aadba1d2",
-      "0bd74992-e471-43f8-823e-32eb002969f3",
-      "517a844e-983d-4ce1-969b-ecc813d36cf6",
-      "9e02b7c4-c50b-40e0-99f4-65cea53ff2ac"
+      "349e24be-d823-4b9c-bf41-0a3c3b03082d",
+      "9f9d4eee-3baa-4473-9b4e-a7d5bc83255d",
+      "a3748dbd-b764-42bf-a3af-85b694fff3cc",
+      "0d953cb3-a685-450d-ac6f-a7930eb766b6",
+      "dec34f08-9806-499e-97e6-2399c96f95e7",
+      "b3768ee6-622f-455f-b380-974ef41196db",
+      "1f15b617-62a0-42ef-a7f3-e69eb3bdbb63",
+      "97a9cb14-639a-4fb0-aadd-647f27f7e858"
     ]
   },
   "changeNote": "",
@@ -63,7 +107,7 @@
   "creators": [
     "admin"
   ],
-  "description": "",
+  "description": "The banner block displays a full-width image banner with one or two lines of text overlaid on a gradient. It can be shown at layout or full width.",
   "effective": "2026-02-11T14:24:00+00:00",
   "exclude_from_nav": false,
   "expires": null,

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/e090d954d0a448bca81c1a646e673a12/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/e090d954d0a448bca81c1a646e673a12/data.json
@@ -79,7 +79,7 @@
       "align": "wide",
       "styles": {},
       "theme": "grey",
-      "title": "kitconcept GmbH, Bonn (OpenStreetMap)",
+      "title": "kitconcept GmbH, Bonn (OpenStreetMap, grey background)",
       "url": "https://www.openstreetmap.org/export/embed.html?bbox=7.09846%2C50.72757%2C7.10692%2C50.73096&layer=mapnik&marker=50.72926%2C7.10274"
     },
     "8019a7ab-8e74-464e-a06a-315648126075": {

--- a/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/e090d954d0a448bca81c1a646e673a12/data.json
+++ b/backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content/e090d954d0a448bca81c1a646e673a12/data.json
@@ -34,6 +34,14 @@
         }
       ]
     },
+    "59842716-5aa5-455c-b7ca-5d6f19746b51": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "OpenStreetMap",
+      "styles": {},
+      "tag": "h2",
+      "theme": "default"
+    },
     "642c75ac-0c4a-4138-8ad7-954a3fa561e6": {
       "@type": "maps",
       "align": "left",
@@ -66,6 +74,21 @@
         }
       ]
     },
+    "7e9eae1a-1772-4c03-b3fe-bda52abd46fc": {
+      "@type": "maps",
+      "align": "wide",
+      "styles": {},
+      "theme": "grey",
+      "title": "kitconcept GmbH, Bonn (OpenStreetMap)",
+      "url": "https://www.openstreetmap.org/export/embed.html?bbox=7.09846%2C50.72757%2C7.10692%2C50.73096&layer=mapnik&marker=50.72926%2C7.10274"
+    },
+    "8019a7ab-8e74-464e-a06a-315648126075": {
+      "@type": "maps",
+      "align": "wide",
+      "styles": {},
+      "title": "kitconcept GmbH, Bonn (OpenStreetMap)",
+      "url": "https://www.openstreetmap.org/export/embed.html?bbox=7.09846%2C50.72757%2C7.10692%2C50.73096&layer=mapnik&marker=50.72926%2C7.10274"
+    },
     "96789bf6-953b-4777-a022-0f4cd852be64": {
       "@type": "separator",
       "styles": {
@@ -77,6 +100,22 @@
         },
         "shortLine": false
       }
+    },
+    "9b9a10d0-08bd-4ee5-9d78-c5a3fcd68f55": {
+      "@type": "slate",
+      "plaintext": "The maps block also supports OpenStreetMap embeds. Paste the embed code from openstreetmap.org and the block extracts the map URL.",
+      "styles": {},
+      "theme": "default",
+      "value": [
+        {
+          "children": [
+            {
+              "text": "The maps block also supports OpenStreetMap embeds. Paste the embed code from openstreetmap.org and the block extracts the map URL."
+            }
+          ],
+          "type": "p"
+        }
+      ]
     },
     "aaf7adb1-00b2-4cc2-8729-91c33ea8fe6a": {
       "@type": "slate",
@@ -150,6 +189,30 @@
         "shortLine": true
       }
     },
+    "d79b5864-cb5b-4bed-862e-3cd4f32f5355": {
+      "@type": "heading",
+      "alignment": "left",
+      "heading": "Grey Background",
+      "styles": {},
+      "tag": "h2",
+      "theme": "grey"
+    },
+    "d7d38e6f-1fd8-46aa-b31d-59a1b277e425": {
+      "@type": "slate",
+      "plaintext": "An OpenStreetMap embed displayed on a grey background.",
+      "styles": {},
+      "theme": "grey",
+      "value": [
+        {
+          "children": [
+            {
+              "text": "An OpenStreetMap embed displayed on a grey background."
+            }
+          ],
+          "type": "p"
+        }
+      ]
+    },
     "e36a9020-5e7e-4ef5-97f7-862c45fea81c": {
       "@type": "maps",
       "align": "wide",
@@ -177,7 +240,13 @@
       "aaf7adb1-00b2-4cc2-8729-91c33ea8fe6a",
       "43a4b392-f0c3-4b8d-a17d-9b4ddea3f0f0",
       "ceee1cfa-80ff-44f1-b3af-3cfd4be3f4ba",
-      "f9dec030-b72d-4940-af4c-6dc123cea7a6"
+      "f9dec030-b72d-4940-af4c-6dc123cea7a6",
+      "59842716-5aa5-455c-b7ca-5d6f19746b51",
+      "9b9a10d0-08bd-4ee5-9d78-c5a3fcd68f55",
+      "8019a7ab-8e74-464e-a06a-315648126075",
+      "d79b5864-cb5b-4bed-862e-3cd4f32f5355",
+      "d7d38e6f-1fd8-46aa-b31d-59a1b277e425",
+      "7e9eae1a-1772-4c03-b3fe-bda52abd46fc"
     ]
   },
   "changeNote": "",


### PR DESCRIPTION
## Summary

Applies the same example-content improvements we made in the website ([kitconcept-website#57](https://github.com/kitconcept/kitconcept-website/pull/57)) and intranet ([kitconcept.intranet#487](https://github.com/kitconcept/kitconcept.intranet/pull/487)) distributions to the theme's own **Blocks example content** (`backend/src/kitconcept/voltolighttheme/setuphandlers/examplecontent/content`). Here the example blocks live under `/block` (not `/qa/block`).

The content is a Plone import stored as per-UID `data.json` files. Grey backgrounds use the `"theme": "grey"` mechanism.

## Changes

| Page | Change |
|------|--------|
| `/block/banner-block` | Added description; replaced the banners with proper variations: full-width / layout-width, single- vs two-line, and a grey-background banner, each under its own heading |
| `/block/carousel-block` | Added description + a grey-background section |
| `/block/event-calendar` | Added description; added a grey-background section; removed an orphaned block keyed `"undefined"` left in the data |
| `/block/logos-block` | Added description |
| `/block/maps-block` | Added an **OpenStreetMap** example + a grey-background section |

## What does NOT apply here (unlike the website / intranet distributions)

- **No `/qa` → "Quality Assurance" title rename** — the section is rooted at `/block` (title "Blocks").
- **No Form block** in this example content, so the form fixes don't apply.
- **Logos images already resolve** — the Plone SVG genuinely exists here with UID `c7a92b57…`; the website's broken-logo bug came from that UID changing during export. Only a description was added.
- **Table margin fix** is a theme (SCSS) change handled at the source, not example content.

## Notes

- All Maps blocks are gated behind the DSGVO `google` consent module *by block type* (not by URL), so the OpenStreetMap example shows the consent placeholder until cookies are accepted, then renders.
- Transforms are identical to the already-verified website changes (same block structures, different UIDs); JSON validated after edits (all files parse, no orphaned blocks).
