### PR TITLE
Enforce OVERRIDE header on shadowed components in CI

### DIFF
--- a/.github/scripts/check-shadow-headers.mjs
+++ b/.github/scripts/check-shadow-headers.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * Check that every shadowed component in a `src/customizations` folder carries
+ * the team's mandatory "OVERRIDE" documentation header at the top of the file.
+ *
+ * This script is intentionally repo-agnostic so it can be dropped into any
+ * Volto/Aurora add-on or project. It assumes the conventional add-on layout
+ * where every add-on lives under a `packages/` folder and keeps its shadowed
+ * components in `<addon>/src/customizations`.
+ *
+ * The header must be the leading block comment of the file and must contain,
+ * at minimum, the following labels:
+ *
+ *   OVERRIDE, REASON, FILE, FILE VERSION, DATE
+ *
+ * PULL REQUEST, TICKET and CHANGELOG are optional and not enforced here.
+ *
+ * Usage:
+ *   node check-shadow-headers.mjs [<root> ...]
+ *
+ * Each <root> is either:
+ *   - a packages root (e.g. `frontend/packages`): every immediate child that
+ *     has a `src/customizations` folder is discovered and checked, or
+ *   - a single add-on package (one that itself contains `src/customizations`).
+ *
+ * If no root is given it defaults to `packages` relative to the current working
+ * directory.
+ *
+ * Exits non-zero (and emits GitHub Actions annotations when run in CI) if any
+ * customization file is missing the header or any required label.
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, relative, resolve, sep, extname } from 'node:path';
+
+const repoRoot = process.cwd();
+
+const roots = (
+  process.argv.slice(2).length > 0 ? process.argv.slice(2) : ['packages']
+).map((dir) => resolve(repoRoot, dir));
+
+const CUSTOMIZATIONS_SUBDIR = join('src', 'customizations');
+
+/**
+ * Resolve the list of `src/customizations` directories to check for a given
+ * root. A root can be a single add-on package or a packages folder holding
+ * many add-ons.
+ */
+function discoverCustomizationsDirs(root) {
+  if (!existsSync(root)) {
+    console.log(
+      `Path ${relative(repoRoot, root) || root} does not exist, skipping.`,
+    );
+    return [];
+  }
+  // Root is itself an add-on package.
+  const ownDir = join(root, CUSTOMIZATIONS_SUBDIR);
+  if (existsSync(ownDir)) {
+    return [ownDir];
+  }
+  // Otherwise treat root as a packages folder and look one level down.
+  const dirs = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const candidate = join(root, entry.name, CUSTOMIZATIONS_SUBDIR);
+    if (existsSync(candidate)) {
+      dirs.push(candidate);
+    }
+  }
+  return dirs;
+}
+
+const targets = roots.flatMap(discoverCustomizationsDirs);
+
+// Files that live under customizations but are not shadowed components and
+// therefore need no header (extend as needed).
+const IGNORE_BASENAMES = new Set(['.gitkeep', '.DS_Store']);
+
+// Asset file types that cannot carry a leading JS block comment without
+// breaking their parser (e.g. SVGs consumed by SVGR/XML). Shadowing these is
+// valid, but the header convention does not apply to them.
+const IGNORE_EXTENSIONS = new Set([
+  '.svg',
+  '.png',
+  '.jpg',
+  '.jpeg',
+  '.gif',
+  '.webp',
+  '.ico',
+]);
+
+// Labels that must be present inside the leading comment block.
+const REQUIRED_LABELS = [
+  { name: 'OVERRIDE', re: /\bOVERRIDE\b/ },
+  { name: 'REASON', re: /\bREASON\s*:/ },
+  { name: 'FILE', re: /\bFILE\s*:/ },
+  { name: 'FILE VERSION', re: /\bFILE VERSION\s*:/ },
+  { name: 'DATE', re: /\bDATE\s*:/ },
+];
+
+const isCI = Boolean(process.env.GITHUB_ACTIONS);
+
+function walk(dir) {
+  let files = [];
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return files;
+  }
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files = files.concat(walk(full));
+    } else if (
+      entry.isFile() &&
+      !IGNORE_BASENAMES.has(entry.name) &&
+      !IGNORE_EXTENSIONS.has(extname(entry.name).toLowerCase())
+    ) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+/**
+ * Return the leading block comment of a source file, or null if the file does
+ * not start with one (ignoring leading whitespace and an optional shebang).
+ */
+function leadingComment(source) {
+  let text = source;
+  if (text.startsWith('#!')) {
+    text = text.slice(text.indexOf('\n') + 1);
+  }
+  const match = text.match(/^\s*\/\*[\s\S]*?\*\//);
+  return match ? match[0] : null;
+}
+
+function checkFile(file) {
+  const source = readFileSync(file, 'utf8');
+  const comment = leadingComment(source);
+  if (comment === null) {
+    return ['missing the leading OVERRIDE header comment block'];
+  }
+  const missing = REQUIRED_LABELS.filter(
+    (label) => !label.re.test(comment),
+  ).map((label) => label.name);
+  if (missing.length > 0) {
+    return [`header is missing required label(s): ${missing.join(', ')}`];
+  }
+  return [];
+}
+
+const files = targets.flatMap((target) => walk(target));
+
+if (files.length === 0) {
+  console.log('No customization files found. Nothing to check.');
+  process.exit(0);
+}
+
+let failures = 0;
+
+for (const file of files) {
+  const rel = relative(repoRoot, file).split(sep).join('/');
+  const problems = checkFile(file);
+  if (problems.length === 0) {
+    console.log(`✓ ${rel}`);
+    continue;
+  }
+  failures += 1;
+  for (const problem of problems) {
+    const message = `Shadowed component ${rel} ${problem}. Add the mandatory OVERRIDE header (OVERRIDE, REASON, FILE, FILE VERSION, DATE) to the top of the file.`;
+    if (isCI) {
+      console.log(`::error file=${rel}::${message}`);
+    } else {
+      console.error(`✗ ${message}`);
+    }
+  }
+}
+
+console.log(
+  `\nChecked ${files.length} customization file(s): ${files.length - failures} ok, ${failures} failing.`,
+);
+
+if (failures > 0) {
+  process.exit(1);
+}

--- a/.github/workflows/frontend-shadow-headers.yml
+++ b/.github/workflows/frontend-shadow-headers.yml
@@ -1,0 +1,24 @@
+name: Shadow customization headers
+
+on:
+  workflow_call:
+    inputs:
+      node-version:
+        required: true
+        type: string
+
+jobs:
+  shadow-headers:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Main checkout
+        uses: actions/checkout@v7
+
+      - name: Use Node.js ${{ inputs.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ inputs.node-version }}
+
+      - name: Check OVERRIDE headers on shadowed components
+        run: node .github/scripts/check-shadow-headers.mjs frontend/packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,15 @@ jobs:
         node-version: ${{ needs.config.outputs.node-version }}
     if: ${{ needs.config.outputs.frontend == 'true' }}
 
+  frontend-shadow-headers:
+    name: "Frontend: Check shadow customization headers"
+    uses: ./.github/workflows/frontend-shadow-headers.yml
+    needs:
+        - config
+    with:
+        node-version: ${{ needs.config.outputs.node-version }}
+    if: ${{ needs.config.outputs.frontend == 'true' }}
+
   frontend-build:
     name: "Frontend: Build container image (${{ needs.config.outputs.base-tag }})"
     if: ${{ needs.config.outputs.acceptance == 'true' && (always() && !contains(needs.*.result, 'failure'))}}
@@ -109,6 +118,7 @@ jobs:
       - frontend-lint
       - frontend-i18n
       - frontend-unit
+      - frontend-shadow-headers
     with:
       base-tag: ${{ needs.config.outputs.base-tag }}
       image-name-prefix: ${{ needs.config.outputs.image-name-prefix }}
@@ -285,6 +295,7 @@ jobs:
       - frontend-lint
       - frontend-unit
       - frontend-i18n
+      - frontend-shadow-headers
       - frontend-build
       - acceptance
       - playwright-acceptance
@@ -307,6 +318,7 @@ jobs:
           echo '| frontend-lint | ${{ needs.frontend-lint.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| frontend-unit | ${{ needs.frontend-unit.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| frontend-i18n | ${{ needs.frontend-i18n.result }} |' >> $GITHUB_STEP_SUMMARY
+          echo '| frontend-shadow-headers | ${{ needs.frontend-shadow-headers.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| frontend-build | ${{ needs.frontend-build.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| acceptance | ${{ needs.acceptance.result }} |' >> $GITHUB_STEP_SUMMARY
           echo '| playwright-acceptance | ${{ needs.playwright-acceptance.result }} |' >> $GITHUB_STEP_SUMMARY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,27 @@ Cypress specs live under `frontend/cypress/tests`.
 - When changing frontend behavior, consider whether the change belongs in `frontend/packages/volto-light-theme` or in the vendored Volto core area.
 - When changing exported backend content or distribution setup, verify whether the change affects demo data, installation defaults, or test fixtures.
 
+## Component Shadowing
+
+Every shadowed Volto/add-on component committed under `frontend/packages/*/src/customizations/` MUST start with the mandatory OVERRIDE documentation header. This is enforced in CI by the `frontend-shadow-headers` job in `.github/workflows/main.yml` (defined in `.github/workflows/frontend-shadow-headers.yml`, script: `.github/scripts/check-shadow-headers.mjs`), which fails the build if the header or any required label is missing.
+
+Required labels in the leading block comment: `OVERRIDE`, `REASON`, `FILE`, `FILE VERSION`, `DATE`. Optional: `PULL REQUEST`, `TICKET`, `CHANGELOG`, `DEVELOPER`.
+
+Template:
+
+```jsx
+/**
+ * OVERRIDE ComponentName.jsx
+ * REASON: Short explanation of why this component is shadowed.
+ * FILE: https://github.com/plone/volto/blob/<version>/packages/volto/src/.../ComponentName.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2026-09-10
+ * DEVELOPER: @your-handle
+ */
+```
+
+Run the check locally from `frontend/`: `pnpm check:shadow` (or `node ../.github/scripts/check-shadow-headers.mjs packages`). Asset files (`.svg`, images) cannot carry the header and are skipped automatically.
+
 ## Changelog Fragments
 
 This repo checks for towncrier fragments in CI.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "test": "pnpm --filter @kitconcept/volto-light-theme exec vitest",
     "lint": "VOLTOCONFIG=$(pwd)/volto.config.js eslint --max-warnings=0 'packages/**/src/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "VOLTOCONFIG=$(pwd)/volto.config.js eslint --fix 'packages/**/src/**/*.{js,jsx,ts,tsx}'",
+    "check:shadow": "node ../.github/scripts/check-shadow-headers.mjs packages",
     "prettier": "prettier --check 'packages/**/src/**/*.{js,jsx,ts,tsx}'",
     "prettier:fix": "prettier --write 'packages/**/src/**/*.{js,jsx,ts,tsx}' ",
     "stylelint": "stylelint 'packages/**/src/**/*.{css,scss,less}' --allow-empty-input",

--- a/frontend/packages/volto-light-theme/news/+shadow-headers.internal
+++ b/frontend/packages/volto-light-theme/news/+shadow-headers.internal
@@ -1,0 +1,1 @@
+Enforce the mandatory OVERRIDE header on shadowed components in CI (shadow-headers check).

--- a/frontend/packages/volto-light-theme/src/customizations/@root/theme.js
+++ b/frontend/packages/volto-light-theme/src/customizations/@root/theme.js
@@ -1,3 +1,12 @@
+/**
+ * OVERRIDE theme.js
+ * REASON: Enable the escape hatch to use SCSS as the theme entry point so VLT
+ * can override the Semantic UI theme with `@kitconcept/volto-light-theme/theme/main.scss`.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/theme.js
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-12-14
+ */
+
 // This customization allows to enable the scape hatch to use
 // SCSS as a theme to override the SemanticUI theme.
 import 'semantic-ui-less/semantic.less';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Block/Edit.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Block/Edit.jsx
@@ -3,6 +3,8 @@
  * REASON: Adding BlockModelv3 wrappers
  * DATE: 2024-02-01
  * DEVELOPER: @sneridagh
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Block/Edit.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import Edit from '../../../../../../components/Blocks/Block/Edit';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Block/EditBlockWrapper.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Block/EditBlockWrapper.jsx
@@ -3,6 +3,8 @@
  * REASON: Removing duplicated className in wrapper only in v3 blocks & add category className to block-editor-{type}
  * DATE: 2024-02-01
  * DEVELOPER: @sneridagh
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Block/EditBlockWrapper.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 import EditBlockWrapper from '../../../../../../components/Blocks/Block/EditBlockWrapper';
 

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/Edit.jsx
@@ -2,6 +2,9 @@
  * OVERRIDE Edit.jsx
  * REASON: This theme introduces the concept of "Caption" and uses `figure`
  * tag for the image.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Image/Edit.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-07-28
  */
 
 import ImageEdit from '../../../../../../components/Blocks/Image/Edit';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/ImageSidebar.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/ImageSidebar.jsx
@@ -2,6 +2,9 @@
  * OVERRIDE ImageSidebar.jsx
  * REASON: There are some specific behavior that we want to enforce to the sizes
  * and alignment settings
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Image/ImageSidebar.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-07-28
  */
 
 import ImageSidebar from '../../../../../../components/Blocks/Image/ImageSidebar';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/View.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Image/View.jsx
@@ -2,6 +2,9 @@
  * OVERRIDE View.jsx
  * REASON: This theme introduces the concept of "Caption" and uses `figure`
  * tag for the image.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Image/View.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-07-28
  */
 
 import ImageView from '../../../../../../components/Blocks/Image/View';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/DefaultTemplate.jsx
@@ -9,6 +9,9 @@
  * still using h2 and change it (if appropiate) when the change is made.
  * To override it, override the @kitconcept/volto-light-theme one instead of
  * this one.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Listing/DefaultTemplate.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-01-19
  */
 
 import DefaultTemplate from '../../../../../../components/Blocks/Listing/DefaultTemplate';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/ImageGallery.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/ImageGallery.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE ImageGallery.jsx
  * REASON: To implement Title, Description and Copyright info.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Listing/ImageGallery.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-11-28
  */
 
 import ImageGallery from '../../../../../../components/Blocks/Listing/ImageGallery';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/ListingBody.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE ListingBody.jsx
  * REASON: To implement Pagination Wrapper according to Theme style.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Listing/ListingBody.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-01-19
  */
 
 import ListingBody from '../../../../../../components/Blocks/Listing/ListingBody';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/SummaryTemplate.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Listing/SummaryTemplate.jsx
@@ -4,6 +4,9 @@
  * depenging on the item's content type for the Summary listing variation.
  * To override it, override the @kitconcept/volto-light-theme one instead of
  * this one.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Listing/SummaryTemplate.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-06-07
  */
 
 import SummaryTemplate from '../../../../../../components/Blocks/Listing/SummaryTemplate';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Maps/MapsSidebar.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Maps/MapsSidebar.jsx
@@ -3,6 +3,8 @@
  * REASON: Route field changes through dataAdapter to enforce default block width when floating.
  * DATE: 2026-04-16
  * DEVELOPER: @danalvrz
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Maps/MapsSidebar.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import MapsSidebar from '../../../../../../components/Blocks/Maps/MapsSidebar';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Maps/View.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Maps/View.jsx
@@ -3,6 +3,8 @@
  * REASON: Use align:noprefix and blockWidth:noprefix CSS custom properties instead of align class.
  * DATE: 2026-04-16
  * DEVELOPER: @danalvrz
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Maps/View.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import MapsView from '../../../../../../components/Blocks/Maps/View';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Search/components/SearchDetails.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE SearchDetails.jsx
  * REASON: Special template for displaying this component, use h2 instead of h4
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Search/components/SearchDetails.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-01-19
  */
 
 import SearchDetails from '../../../../../../../components/Blocks/Search/components/SearchDetails';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Search/components/SearchInput.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Search/components/SearchInput.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE SearchInput.jsx
  * REASON: Special template for displaying this component
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Search/components/SearchInput.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2023-01-19
  */
 
 import SearchInput from '../../../../../../../components/Blocks/Search/components/SearchInput';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Teaser/Body.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Teaser/Body.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE Body.jsx
  * REASON: Better wrap for Teasers.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Teaser/Body.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2025-06-04
  */
 
 import TeaserBody from '../../../../../../components/Blocks/Teaser/Body';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Teaser/DefaultBody.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Teaser/DefaultBody.jsx
@@ -1,6 +1,9 @@
 /**
  * OVERRIDE DefaultBody.jsx
  * REASON: Look up Summary component.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Teaser/DefaultBody.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2025-02-11
  */
 
 import DefaultBody from '../../../../../../components/Blocks/Teaser/DefaultBody';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Video/VideoSidebar.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Video/VideoSidebar.jsx
@@ -3,6 +3,8 @@
  * REASON: Route field changes through dataAdapter to enforce default block width when floating.
  * DATE: 2026-04-16
  * DEVELOPER: @danalvrz
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Video/VideoSidebar.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import VideoSidebar from '../../../../../../components/Blocks/Video/VideoSidebar';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Video/View.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/Blocks/Video/View.jsx
@@ -3,6 +3,8 @@
  * REASON: Use align:noprefix and blockWidth:noprefix CSS custom properties instead of align class.
  * DATE: 2026-04-16
  * DEVELOPER: @danalvrz
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/Blocks/Video/View.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import VideoView from '../../../../../../components/Blocks/Video/View';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/DragDropList/DragDropList.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/manage/DragDropList/DragDropList.jsx
@@ -4,6 +4,8 @@
  *  Not moved to core yet, and as it's temporary, we keep it here.
  * DATE: 2025-12-01
  * DEVELOPER: @sneridagh
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/manage/DragDropList/DragDropList.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import React, { useRef } from 'react';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Anontools/Anontools.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Anontools/Anontools.jsx
@@ -4,6 +4,9 @@
  * SemanticUI-free located at the components folder.
  * To override it, override the @kitconcept/volto-light-theme one instead of
  * this one.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Anontools/Anontools.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import Anontools from '../../../../../components/Anontools/Anontools';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Breadcrumbs/Breadcrumbs.jsx
@@ -4,6 +4,9 @@
  * project can swap it via `config.settings.vlt.components.breadcrumbs` instead
  * of shadowing this file. To replace it, register your own utility and flip the
  * setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Breadcrumbs/Breadcrumbs.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Footer/Footer.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Footer/Footer.jsx
@@ -3,6 +3,9 @@
  * REASON: VLT resolves the footer through the component registry so a project
  * can swap it via `config.settings.vlt.components.footer` instead of shadowing
  * this file. To replace it, register your own utility and flip the setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Footer/Footer.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Header/Header.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Header/Header.jsx
@@ -3,6 +3,9 @@
  * REASON: VLT resolves the header through the component registry so a project
  * can swap it via `config.settings.vlt.components.header` instead of shadowing
  * this file. To replace it, register your own utility and flip the setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Header/Header.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/LanguageSelector/LanguageSelector.tsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/LanguageSelector/LanguageSelector.tsx
@@ -4,6 +4,9 @@
  * a project can swap it via `config.settings.vlt.components.languageSelector`
  * instead of shadowing this file. To replace it, register your own utility and
  * flip the setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/LanguageSelector/LanguageSelector.tsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2026-02-09
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Logo/Logo.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Logo/Logo.jsx
@@ -3,6 +3,9 @@
  * REASON: VLT resolves the logo through the component registry so a project can
  * swap it via `config.settings.vlt.components.logo` instead of shadowing this
  * file. To replace it, register your own utility and flip the setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Logo/Logo.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Navigation/Navigation.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Navigation/Navigation.jsx
@@ -4,6 +4,9 @@
  * project can swap it via `config.settings.vlt.components.navigation` instead
  * of shadowing this file. To replace it, register your own utility and flip the
  * setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Navigation/Navigation.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/SearchWidget/SearchWidget.jsx
@@ -4,6 +4,9 @@
  * project can swap it via `config.settings.vlt.components.searchWidget` instead
  * of shadowing this file. To replace it, register your own utility and flip the
  * setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/SearchWidget/SearchWidget.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Tags/Tags.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/Tags/Tags.jsx
@@ -3,6 +3,9 @@
  * REASON: VLT resolves the tags through the component registry so a project can
  * swap it via `config.settings.vlt.components.tags` instead of shadowing this
  * file. To replace it, register your own utility and flip the setting.
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/Tags/Tags.jsx
+ * FILE VERSION: Volto 19.3.0
+ * DATE: 2022-11-03
  */
 
 import { getVLTComponent } from '@kitconcept/volto-light-theme/helpers/settings';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/FileView.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/FileView.jsx
@@ -3,6 +3,8 @@
  * REASON: Adding size of file.
  * DATE: 2023-07-11
  * DEVELOPER: @iRohitSingh
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/View/FileView.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import FileView from '../../../../../components/Theme/FileView';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/ImageView.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/ImageView.jsx
@@ -3,6 +3,8 @@
  * REASON: Using custom component to render Image and Caption.
  * DATE: 2023-07-19
  * DEVELOPER: @IFlameing
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/View/ImageView.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import ImageView from '../../../../../components/Theme/ImageView';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/NewsItemView.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/NewsItemView.jsx
@@ -3,6 +3,8 @@
  * REASON: Adding dates and headtitle above the title of page.
  * DATE: 2023-07-04
  * DEVELOPER: @IFlameing
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/View/NewsItemView.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import NewsItemView from '../../../../../components/Theme/NewsItemView';

--- a/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/RenderBlocks.jsx
+++ b/frontend/packages/volto-light-theme/src/customizations/volto/components/theme/View/RenderBlocks.jsx
@@ -3,6 +3,8 @@
  * REASON: This customization supports Block Model v3, along with the previous implementation.
  * DATE: 2024-02-08
  * DEVELOPER: @sneridagh
+ * FILE: https://github.com/plone/volto/blob/19.3.0/packages/volto/src/components/theme/View/RenderBlocks.jsx
+ * FILE VERSION: Volto 19.3.0
  */
 
 import RenderBlocks from '../../../../../components/Theme/RenderBlocks';

--- a/news/+shadow-headers.internal
+++ b/news/+shadow-headers.internal
@@ -1,0 +1,1 @@
+Enforce the mandatory OVERRIDE header on shadowed components in CI (shadow-headers check).


### PR DESCRIPTION
## What

Ports the shadow-headers check from kitconcept/volto-plate#69 and backfills all existing shadowed components.

- **`.github/scripts/check-shadow-headers.mjs`** — dependency-free, repo-agnostic Node script. Auto-discovers each `frontend/packages/*/src/customizations` folder and fails if any shadowed component is missing the mandatory `OVERRIDE` header.
- **`.github/workflows/frontend-shadow-headers.yml`** (new) + **`main.yml`** — VLT uses the split `frontend-*.yml` CI style rather than a reusable `frontend.yml`, so the check ships as its own reusable workflow, wired in as `frontend-shadow-headers` (gates `frontend-build`, listed in the final report).
- **`frontend/package.json`** — `check:shadow` script (`pnpm check:shadow` from `frontend/`).
- **`AGENTS.md`** — documents the convention and header template.
- **Backfill** — added/completed the header on all 32 shadowed components. Check is now green (32/32).

Required labels: `OVERRIDE`, `REASON`, `FILE`, `FILE VERSION`, `DATE`.

## Backfill provenance (please sanity-check)

- Existing header values were preserved; only missing labels were filled. Most files already had `OVERRIDE / REASON / DATE / DEVELOPER` and just needed `FILE` + `FILE VERSION`.
- `FILE` derived from the upstream Volto path; `FILE VERSION: Volto 19.3.0` (the pinned core); missing `DATE` recovered via `git log --follow` (real historical dates, not the folder-migration date).
- `@root/theme.js` had no block comment and got a **hand-written `REASON`** worth reviewing.

## Note

The script skips asset files (`.svg`, images) that cannot carry a JS block comment — this covers the 3 shadowed SVG icons (`sort-up`, `sort-down`, `default-image`). This is a small divergence from volto-plate's script and is worth upstreaming there.